### PR TITLE
[*] MO : Adds post validate hook to ProductComment model

### DIFF
--- a/ProductComment.php
+++ b/ProductComment.php
@@ -305,10 +305,14 @@ class ProductComment extends ObjectModel
 	{
 		if (!Validate::isUnsignedId($this->id))
 			return false;
-		return (Db::getInstance()->execute('
+
+		$success = (Db::getInstance()->execute('
 		UPDATE `'._DB_PREFIX_.'product_comment` SET
 		`validate` = '.(int)$validate.'
 		WHERE `id_product_comment` = '.(int)$this->id));
+
+		Hook::exec('actionObjectProductCommentValidateAfter', array('object' => $this));
+		return $success;
 	}
 
 	/**


### PR DESCRIPTION
This fires a new hook, `actionObjectProductCommentValidateAfter` after a ProductComment has been validated. This would allow other modules to fully hook in to ProductComment functionality (creation, deletion and validation).

Creation and deletion are already served by the existing `actionObjectProductCommentAddAfter` and `actionObjectProductCommentAddAfter` hooks.
