### PR TITLE
[-] FO: Include CSS only in product and comparison pages

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -859,11 +859,10 @@ class ProductComments extends Module
 
 	public function hookHeader()
 	{
-		$this->context->controller->addCSS($this->_path.'productcomments.css', 'all');
-
 		$this->page_name = Dispatcher::getInstance()->getController();
 		if (in_array($this->page_name, array('product', 'productscomparison')))
 		{
+			$this->context->controller->addCSS($this->_path.'productcomments.css', 'all');
 			$this->context->controller->addJS($this->_path.'js/jquery.rating.pack.js');
 			if (in_array($this->page_name, array('productscomparison')))
 			{


### PR DESCRIPTION
Seems like the CSS is included everywhere but is only used in product and comparison pages.

I checked the styles > templates with corresponding elements > methods that render these templates > controllers that call the module hook methods.

Someone please double check maybe there's something I'm missing, like some king of display in quick view / product miniature?
