### PR TITLE
Listening event on product refresh to construct stars again

### DIFF
--- a/views/js/list-comments.js
+++ b/views/js/list-comments.js
@@ -35,6 +35,10 @@ jQuery(document).ready(function () {
   emptyProductComment.hide();
   $('.grade-stars').rating();
 
+  document.addEventListener('updateRating', function() {
+    $('.grade-stars').rating();
+  });
+
   const updateCommentPostErrorModal = $('#update-comment-usefulness-post-error');
 
   const confirmAbuseModal = $('#report-comment-confirmation');
@@ -54,6 +58,7 @@ jQuery(document).ready(function () {
   function paginateComments(page) {
     $.get(commentsListUrl, {page: page}, function(result) {
       const jsonResponse = JSON.parse(result);
+
       if (jsonResponse.comments && jsonResponse.comments.length > 0) {
         populateComments(jsonResponse.comments);
         if (jsonResponse.comments_nb > jsonResponse.comments_per_page) {


### PR DESCRIPTION
Needs to be merged before https://github.com/PrestaShop/PrestaShop/pull/17020

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Listening event on product refresh to construct stars again
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes partially https://github.com/PrestaShop/PrestaShop/issues/15184
| How to test?  | You need to activate review on products, send one review at least on a product, go on product page and change quantity for example or combination, stars needs to stay, while before stars were disappearing !