### PR TITLE
Force installation in all stores context

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -62,6 +62,10 @@ class ProductComments extends Module
 
     public function install($keep = true)
     {
+        if (Shop::isFeatureActive()) {
+            Shop::setContext(Shop::CONTEXT_ALL);
+        }
+	
         if ($keep) {
             if (!file_exists(dirname(__FILE__) . '/' . self::INSTALL_SQL_FILE)) {
                 return false;


### PR DESCRIPTION
This is related to this issue:
https://github.com/PrestaShop/PrestaShop/issues/19811

If you never had `productomments` in your store, and you'll install module in context of only second store, you'll have troubles with messed up configuration, for example some options will only be read from context of All stores at first

Steps to test:

1. multi-store enabled with at least two stores First and Second
2. go to "Second" store context, install productcomments
3. enable comments for non logged-in users in second store
4. check if you can add a new comment as a non logged-in user, you can't
5. now go to "All stores", set all settings (because they're empty which is wrong), you want to enable comments for non logged-in users
6. now if you go to Second store product page, you can add a comment for a non logged-in user
7. now go to Second store comments configuration and turn off comments for guests, as you can see **now** you can do that

Overall - in my opinion - it is a good practice to install in the context of all stores in most scenarios

btw. i really hope y'all start to treat multi-store feature more seriously, my biggest customers depends on it, if you want help, consultation or something, i'm available

| Sponsor company  | impSolutions