### PR TITLE
Enable usage as a Widget

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -941,27 +941,24 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderWidget($hookName = null, array $configuration = [])
     {
+        $variables = [];
 
         if('displayProductListReviews' === $hookName || isset($configuration['type']) && 'product_list' === $configuration['type']) {
-
             $product = $configuration['product'];
-            $id_product = $product['id_product'];
-            $variables = $this->getWidgetVariables($hookName, array('id_product' => $id_product));
+            $idProduct = $product['id_product'];
+            $variables = $this->getWidgetVariables($hookName, array('id_product' => $idProduct));
 
             $variables = array_merge($variables, array(
                 'product' => $product,
                 'product_comment_grade_url' => $this->context->link->getModuleLink('productcomments', 'CommentGrade')
             ));
 
-            $file_path = 'module:productcomments/views/templates/hook/product-list-reviews.tpl';
-
+            $filePath = 'module:productcomments/views/templates/hook/product-list-reviews.tpl';
         } elseif ($this->context->controller instanceof ProductControllerCore) {
+            $idProduct = Tools::getValue('id_product');
+            $variables = $this->getWidgetVariables($hookName, array('id_product' => $idProduct));
 
-            $id_product = Tools::getValue('id_product');
-            $variables = $this->getWidgetVariables($hookName, array('id_product' => $id_product));
-
-            $file_path = 'quickview' === Tools::getValue('action') ? 'module:productcomments/views/templates/hook/product-additional-info-quickview.tpl' : 'module:productcomments/views/templates/hook/product-additional-info.tpl';
-    
+            $filePath = 'quickview' === Tools::getValue('action') ? 'module:productcomments/views/templates/hook/product-additional-info-quickview.tpl' : 'module:productcomments/views/templates/hook/product-additional-info.tpl';
         }
 
         if (empty($variables)) {
@@ -970,7 +967,7 @@ class ProductComments extends Module implements WidgetInterface
 
         $this->smarty->assign($variables);
 
-        return $this->fetch($file_path);
+        return $this->fetch($filePath);
     }
 
 }

--- a/productcomments.php
+++ b/productcomments.php
@@ -34,7 +34,7 @@ use PrestaShop\Module\ProductComment\Repository\ProductCommentRepository;
 use PrestaShop\Module\ProductComment\Addons\CategoryFetcher;
 
 class ProductComments extends Module implements WidgetInterface
-{ 
+{
     const INSTALL_SQL_FILE = 'install.sql';
 
     private $_html = '';

--- a/productcomments.php
+++ b/productcomments.php
@@ -942,6 +942,7 @@ class ProductComments extends Module implements WidgetInterface
     public function renderWidget($hookName = null, array $configuration = [])
     {
         $variables = [];
+        $tplHookPath = 'module:productcomments/views/templates/hook/';
 
         if('displayProductListReviews' === $hookName || isset($configuration['type']) && 'product_list' === $configuration['type']) {
             $product = $configuration['product'];
@@ -953,12 +954,12 @@ class ProductComments extends Module implements WidgetInterface
                 'product_comment_grade_url' => $this->context->link->getModuleLink('productcomments', 'CommentGrade')
             ));
 
-            $filePath = 'module:productcomments/views/templates/hook/product-list-reviews.tpl';
+            $filePath = $tplHookPath . 'product-list-reviews.tpl';
         } elseif ($this->context->controller instanceof ProductControllerCore) {
-            $idProduct = Tools::getValue('id_product');
+            $idProduct = $this->context->controller->getProduct()->id;
             $variables = $this->getWidgetVariables($hookName, array('id_product' => $idProduct));
 
-            $filePath = 'quickview' === Tools::getValue('action') ? 'module:productcomments/views/templates/hook/product-additional-info-quickview.tpl' : 'module:productcomments/views/templates/hook/product-additional-info.tpl';
+            $filePath = 'quickview' === Tools::getValue('action') ? $tplHookPath . 'product-additional-info-quickview.tpl' : $tplHookPath . 'product-additional-info.tpl';
         }
 
         if (empty($variables)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Implementing widget interface
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18817
| How to test?  | Add productcomments module to e.g. displayReassurance or add it to product.tpl with {widget name="productcomments"}. Check product page and quickview.

