### PR TITLE
Added Pagination system for Comments in BO

### DIFF
--- a/ProductComment.php
+++ b/ProductComment.php
@@ -277,7 +277,7 @@ class ProductComment extends ObjectModel
      *
      * @return array Comments
      */
-    public static function getByValidate($validate = '0', $p = null, $limit = null, $skip_validate = false)
+    public static function getByValidate($validate = '0', $deleted = false, $p = null, $limit = null, $skip_validate = false)
     {
         $sql = '
 			SELECT pc.`id_product_comment`, pc.`id_product`, IF(c.id_customer, CONCAT(c.`firstname`, \' \',  c.`lastname`), pc.customer_name) customer_name, pc.`title`, pc.`content`, pc.`grade`, pc.`date_add`, pl.`name`

--- a/ProductComment.php
+++ b/ProductComment.php
@@ -277,18 +277,43 @@ class ProductComment extends ObjectModel
      *
      * @return array Comments
      */
-    public static function getByValidate($validate = '0', $deleted = false)
+    public static function getByValidate($validate = '0', $p = null, $limit = null, $skip_validate = false)
     {
         $sql = '
 			SELECT pc.`id_product_comment`, pc.`id_product`, IF(c.id_customer, CONCAT(c.`firstname`, \' \',  c.`lastname`), pc.customer_name) customer_name, pc.`title`, pc.`content`, pc.`grade`, pc.`date_add`, pl.`name`
 			FROM `' . _DB_PREFIX_ . 'product_comment` pc
 			LEFT JOIN `' . _DB_PREFIX_ . 'customer` c ON (c.`id_customer` = pc.`id_customer`)
-			LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pl.`id_product` = pc.`id_product` AND pl.`id_lang` = ' . (int) Context::getContext()->language->id . Shop::addSqlRestrictionOnLang('pl') . ')
-			WHERE pc.`validate` = ' . (int) $validate;
+            LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pl.`id_product` = pc.`id_product` AND pl.`id_lang` = ' . (int) Context::getContext()->language->id . Shop::addSqlRestrictionOnLang('pl') . ')';
+         
+        if(!$skip_validate) {
+            $sql .=	' WHERE pc.`validate` = ' . (int) $validate;
+        }
 
         $sql .= ' ORDER BY pc.`date_add` DESC';
 
+        if($p && $limit) {
+            $offset = ($p - 1) * $limit;
+            $sql .= ' LIMIT ' . (int) $offset . ',' . (int) $limit;
+        }
+
         return Db::getInstance()->executeS($sql);
+    }
+    /**
+     * Get numbers of comments by Validation
+     *
+     * @return int Count of comments
+     */
+    public static function getCountByValidate($validate = '0', $skip_validate = false)
+    {
+        $sql = '
+            SELECT COUNT(*) 
+            FROM `' . _DB_PREFIX_ . 'product_comment`';
+
+        if(!$skip_validate) {
+            $sql .=	' WHERE `validate` = ' . (int) $validate;
+        }
+
+        return Db::getInstance()->getValue($sql);
     }
 
     /**

--- a/productcomments.php
+++ b/productcomments.php
@@ -388,7 +388,7 @@ class ProductComments extends Module
         $return = null;
 
         if (Configuration::get('PRODUCT_COMMENTS_MODERATE')) {
-            $comments = ProductComment::getByValidate(0);
+            $comments = ProductComment::getByValidate(0, false);
 
             $fields_list = $this->getStandardFieldList();
 
@@ -549,10 +549,10 @@ class ProductComments extends Module
 
         $moderate = Configuration::get('PRODUCT_COMMENTS_MODERATE');
         if (empty($moderate)) {
-            $comments = ProductComment::getByValidate(0, (int)$page, (int)$pagination, true);
+            $comments = ProductComment::getByValidate(0, false, (int)$page, (int)$pagination, true);
             $count = (int)ProductComment::getCountByValidate(0, true);
         } else {
-            $comments = ProductComment::getByValidate(1, (int)$page, (int)$pagination);
+            $comments = ProductComment::getByValidate(1, false, (int)$page, (int)$pagination);
             $count = (int)ProductComment::getCountByValidate(1);
         }
 

--- a/productcomments.php
+++ b/productcomments.php
@@ -388,7 +388,7 @@ class ProductComments extends Module
         $return = null;
 
         if (Configuration::get('PRODUCT_COMMENTS_MODERATE')) {
-            $comments = ProductComment::getByValidate(0, false);
+            $comments = ProductComment::getByValidate(0);
 
             $fields_list = $this->getStandardFieldList();
 
@@ -528,27 +528,35 @@ class ProductComments extends Module
     {
         require_once dirname(__FILE__) . '/ProductComment.php';
 
-        $comments = ProductComment::getByValidate(1, false);
-        $moderate = Configuration::get('PRODUCT_COMMENTS_MODERATE');
-        if (empty($moderate)) {
-            $comments = array_merge($comments, ProductComment::getByValidate(0, false));
-        }
-
         $fields_list = $this->getStandardFieldList();
 
         $helper = new HelperList();
         $helper->list_id = 'form-productcomments-list';
         $helper->shopLinkType = '';
-        $helper->simple_header = true;
+        $helper->simple_header = false;
         $helper->actions = array('delete');
         $helper->show_toolbar = false;
         $helper->module = $this;
-        $helper->listTotal = count($comments);
         $helper->identifier = 'id_product_comment';
         $helper->title = $this->trans('Approved Reviews', [], 'Modules.Productcomments.Admin');
         $helper->table = $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+
+
+        $page = ($page = Tools::getValue('submitFilter' . $helper->list_id)) ? $page : 1;
+        $pagination = ($pagination = Tools::getValue($helper->list_id . '_pagination')) ? $pagination : 50;
+
+        $moderate = Configuration::get('PRODUCT_COMMENTS_MODERATE');
+        if (empty($moderate)) {
+            $comments = ProductComment::getByValidate(0, (int)$page, (int)$pagination, true);
+            $count = (int)ProductComment::getCountByValidate(0, true);
+        } else {
+            $comments = ProductComment::getByValidate(1, (int)$page, (int)$pagination);
+            $count = (int)ProductComment::getCountByValidate(1);
+        }
+
+        $helper->listTotal = $count;
 
         return $helper->generateList($comments, $fields_list);
     }
@@ -600,31 +608,38 @@ class ProductComments extends Module
             'id_product_comment' => array(
                 'title' => $this->trans('ID', [], 'Modules.Productcomments.Admin'),
                 'type' => 'text',
+                'search' => false,
             ),
             'title' => array(
                 'title' => $this->trans('Review title', [], 'Modules.Productcomments.Admin'),
                 'type' => 'text',
+                'search' => false,
             ),
             'content' => array(
                 'title' => $this->trans('Review', [], 'Modules.Productcomments.Admin'),
                 'type' => 'text',
+                'search' => false,
             ),
             'grade' => array(
                 'title' => $this->trans('Rating', [], 'Modules.Productcomments.Admin'),
                 'type' => 'text',
                 'suffix' => '/5',
+                'search' => false,
             ),
             'customer_name' => array(
                 'title' => $this->trans('Author', [], 'Modules.Productcomments.Admin'),
                 'type' => 'text',
+                'search' => false,
             ),
             'name' => array(
                 'title' => $this->trans('Product', [], 'Modules.Productcomments.Admin'),
                 'type' => 'text',
+                'search' => false,
             ),
             'date_add' => array(
                 'title' => $this->trans('Time of publication', [], 'Modules.Productcomments.Admin'),
                 'type' => 'date',
+                'search' => false,
             ),
         );
     }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | I added pagination system for comments in BO. In ProductComment I removed unused param `deleted` in method getByValidate and added few more to handle pagination. Also I added new method to this class called getCountByValidate to get value for listTotal for helper list.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/15597
| How to test?  | Add few comments (copy them in sql it will be faster). Change moderate option or accept few by yourself.

