### PR TITLE
Ignore HTML parsing errors in CategoryFetcher::getDescription()

### DIFF
--- a/src/Addons/CategoryFetcher.php
+++ b/src/Addons/CategoryFetcher.php
@@ -215,7 +215,12 @@ class CategoryFetcher
 
         $cssSelector = new CssSelectorConverter();
         $document = new DOMDocument();
+
+        // if fetched HTML is not valid, DOMDocument::loadHtml() will generate E_WARNING warnings
+        libxml_use_internal_errors(true);
         $document->loadHTML($categoryResponse);
+        libxml_use_internal_errors(false);
+
         $xpath = new DOMXPath($document);
         $descriptionNode = $xpath->query($cssSelector->toXPath('#category_description'))->item(0);
         $categoryDescription = '';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Class CategoryFetcher is in charge of scraping (😱) Addons module page to parse some data. Unfortunately the HTML is not valid according to DOMDocument which generates E_WARNING errors that pop up in a nasty way (see screenshot below).<br/>In this PR I ignore these errors (I dont feel good doing it 😅 ) because, well, the description can be extracted even though the HTML is not valid... so I dont think throwing an exception is relevant here.<br/>The errors can be retrieved using `libxml_get_errors()` however I dont know what to do with it. It makes not sense to display to merchant "hi ! the html page we scrap to display an advertising is broken" 😅 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | productcomments v4.1.0 (PR is in QA) has issues with PS 1.7.7 because of that (see screenshot below) as reported by @sarahdib . This PR fixes this nasty issue that prevents v4.1.0 release.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
