### PR TITLE
Fix: Product grade update after product page being updated

### DIFF
--- a/views/js/list-comments.js
+++ b/views/js/list-comments.js
@@ -35,6 +35,10 @@ jQuery(document).ready(function () {
   emptyProductComment.hide();
   $('.grade-stars').rating();
 
+  prestashop.on('updatedProduct', function() {
+    $('.grade-stars').rating();
+  })
+
   document.addEventListener('updateRating', function() {
     $('.grade-stars').rating();
   });

--- a/views/js/list-comments.js
+++ b/views/js/list-comments.js
@@ -36,7 +36,7 @@ jQuery(document).ready(function () {
   $('.grade-stars').rating();
 
   prestashop.on('updatedProduct', function() {
-    $('.grade-stars').rating();
+    $('.product-comments-additional-info .grade-stars').rating();
   })
 
   document.addEventListener('updateRating', function() {


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | With `updateProduct` event block `product_additional_info` is being replaced. Rating have to be updated.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop/issues/21171.
| How to test?  | Go to product page, make sure some comments has been added to product. Add to cart or change combination to emit `updateProduct` event. 

