### PR TITLE
Redirect after noabuseComment submit to prevent resubmit on page reload

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -241,7 +241,7 @@ class ProductComments extends Module implements WidgetInterface
             $comment->validate();
         } elseif ($id_product_comment = (int) Tools::getValue('noabuseComment')) {
             ProductComment::deleteReports($id_product_comment);
-            Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
+            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
         }
 
         $this->_clearcache('productcomments_reviews.tpl');

--- a/productcomments.php
+++ b/productcomments.php
@@ -241,6 +241,7 @@ class ProductComments extends Module implements WidgetInterface
             $comment->validate();
         } elseif ($id_product_comment = (int) Tools::getValue('noabuseComment')) {
             ProductComment::deleteReports($id_product_comment);
+            Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
         }
 
         $this->_clearcache('productcomments_reviews.tpl');


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Page redirect has been added after submiting `noabuseComment` to prevent resubmit on page reload.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/PrestaShop/issues/13368
| How to test?  | Add a comment on product page. Report comment in FO, go to BO and set comment to not being abusive. Go to FO again and report the same comment. Refresh page in BO, report should appear in `REPORTED REVIEWS` table.

