### PR TITLE
Use the correct version of php-cs-fixer

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -26,8 +26,17 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2.0.0
 
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                path: vendor
+                key: php-${{ hashFiles('composer.lock') }}
+
+            - name: Install dependencies
+              run: composer install
+
             - name: Run PHP-CS-Fixer
-              uses: prestashopcorp/github-action-php-cs-fixer@master
+              run: ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --diff-format udiff
 
     # Run PHPStan against the module and a PrestaShop release
     phpstan:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use the composer.lock version of php-cs-fixer instead of a custom one.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | GA are green.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
