### PR TITLE
Fix posted modal backdrop

### DIFF
--- a/views/js/post-comment.js
+++ b/views/js/post-comment.js
@@ -49,7 +49,9 @@ jQuery(document).ready(function () {
     postCommentModal.modal('hide');
     commentPostErrorModal.modal('hide');
     clearPostCommentForm();
-    commentPostedModal.modal('show');
+    window.setTimeout(function() {
+      commentPostedModal.modal('show');
+    }, 500);
   }
 
   function showPostErrorModal(errorMessage) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When submitting a new review, the  confirmation dialog appears to be behind the backdrop. This is likely caused by a timing issue, which is the reason why I added a delay.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | PrestaShop/PrestaShop#24516
| How to test?  | Create a new review and check if the confirmation dialog is in foreground

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
