### PR TITLE
Fix upgrade module to v4

### DIFF
--- a/src/Repository/ProductCommentRepository.php
+++ b/src/Repository/ProductCommentRepository.php
@@ -51,6 +51,8 @@ class ProductCommentRepository
      */
     private $commentsMinimalTime;
 
+    const DEFAULT_COMMENTS_PER_PAGE = 5;
+
     /**
      * @param Connection $connection
      * @param string $databasePrefix
@@ -80,7 +82,7 @@ class ProductCommentRepository
     public function paginate($productId, $page, $commentsPerPage, $validatedOnly)
     {
         if (empty($commentsPerPage)) {
-            $commentsPerPage = 5;
+            $commentsPerPage = self::DEFAULT_COMMENTS_PER_PAGE;
         }
         /** @var QueryBuilder $qb */
         $qb = $this->connection->createQueryBuilder();

--- a/src/Repository/ProductCommentRepository.php
+++ b/src/Repository/ProductCommentRepository.php
@@ -79,6 +79,9 @@ class ProductCommentRepository
      */
     public function paginate($productId, $page, $commentsPerPage, $validatedOnly)
     {
+        if (empty($commentsPerPage)) {
+            $commentsPerPage = 5;
+        }
         /** @var QueryBuilder $qb */
         $qb = $this->connection->createQueryBuilder();
         $qb

--- a/upgrade/install-4.0.0.php
+++ b/upgrade/install-4.0.0.php
@@ -40,5 +40,5 @@ function upgrade_module_4_0_0($object)
     $res &= (bool) $object->registerHook('displayProductAdditionalInfo');
     $res &= (bool) $object->registerHook('displayFooterProduct');
 
-    return $res;
+    return (bool) $res;
 }

--- a/upgrade/install-4.0.0.php
+++ b/upgrade/install-4.0.0.php
@@ -31,10 +31,10 @@ function upgrade_module_4_0_0($object)
 {
     $res = true;
     if (!Configuration::hasKey('PRODUCT_COMMENTS_COMMENTS_PER_PAGE')) {
-        $res &= (bool) Configuration::set('PRODUCT_COMMENTS_COMMENTS_PER_PAGE', 5);
+        $res &= (bool) Configuration::updateValue('PRODUCT_COMMENTS_COMMENTS_PER_PAGE', 5);
     }
     if (!Configuration::hasKey('PRODUCT_COMMENTS_USEFULNESS')) {
-        $res &= (bool) Configuration::set('PRODUCT_COMMENTS_USEFULNESS', 1);
+        $res &= (bool) Configuration::updateValue('PRODUCT_COMMENTS_USEFULNESS', 1);
     }
     $res &= (bool) $object->unregisterHook('displayRightColumnProduct');
     $res &= (bool) $object->registerHook('displayProductAdditionalInfo');

--- a/upgrade/install-4.0.0.php
+++ b/upgrade/install-4.0.0.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_0_0($object)
+{
+    $res = true;
+    if (!Configuration::hasKey('PRODUCT_COMMENTS_COMMENTS_PER_PAGE')) {
+        $res &= (bool) Configuration::set('PRODUCT_COMMENTS_COMMENTS_PER_PAGE', 5);
+    }
+    if (!Configuration::hasKey('PRODUCT_COMMENTS_USEFULNESS')) {
+        $res &= (bool) Configuration::set('PRODUCT_COMMENTS_USEFULNESS', 1);
+    }
+    $res &= (bool) $object->unregisterHook('displayRightColumnProduct');
+    $res &= (bool) $object->registerHook('displayProductAdditionalInfo');
+    $res &= (bool) $object->registerHook('displayFooterProduct');
+
+    return $res;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add required hooks and configuration values for v4 upgrade
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/23218
| How to test?  | see issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
It seems that the upgrade file is not launched at prestashop 1.7 upgrade in some cases. So I added a default commentsPerPage in paginate method