### PR TITLE
Adding link to a customer profile in comments lists

### DIFF
--- a/ProductComment.php
+++ b/ProductComment.php
@@ -282,7 +282,7 @@ class ProductComment extends ObjectModel
     public static function getByValidate($validate = '0', $deleted = false, $p = null, $limit = null, $skip_validate = false)
     {
         $sql = '
-			SELECT pc.`id_product_comment`, pc.`id_product`, IF(c.id_customer, CONCAT(c.`firstname`, \' \',  c.`lastname`), pc.customer_name) customer_name, pc.`title`, pc.`content`, pc.`grade`, pc.`date_add`, pl.`name`
+			SELECT pc.`id_product_comment`, pc.`id_product`, IF(c.id_customer, CONCAT(c.`firstname`, \' \',  c.`lastname`, \' (\',  c.id_customer, \')\'), pc.customer_name) customer_name, pc.`title`, pc.`content`, pc.`grade`, pc.`date_add`, pl.`name`
 			FROM `' . _DB_PREFIX_ . 'product_comment` pc
 			LEFT JOIN `' . _DB_PREFIX_ . 'customer` c ON (c.`id_customer` = pc.`id_customer`)
             LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pl.`id_product` = pc.`id_product` AND pl.`id_lang` = ' . (int) Context::getContext()->language->id . Shop::addSqlRestrictionOnLang('pl') . ')';

--- a/js/moderate.js
+++ b/js/moderate.js
@@ -124,4 +124,14 @@ $( document ).ready(function() {
 	});
 
 	$('select#id_product_comment_criterion_type').trigger( "change" );
+
+	$('table.table.productcomments .product-comment-author').each( function(){
+		let name = $(this).text().trim()
+		let link = $('#subtab-AdminCustomers a').attr('href');
+
+		let match = name.match(/\((\d+)\)/);
+		if (match && match[1]) {
+			$(this).html('<a href="'+link.replace('?',match[1]+'/view?')+'" target="_blank">'+name+'</a>');
+		}
+	})
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adding a link to the customer profile in BO - product comments lists (just like it was done recently in Orders list). This allows moderators to quickly navigate to comment author's profile - e.g. we use this feature to add royalty points to comments authors 
| Type?         | improvement 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
