### PR TITLE
To prevent google from indexing the icon names use data-icon and css to show the icons

### DIFF
--- a/views/css/productcomments.css
+++ b/views/css/productcomments.css
@@ -27,6 +27,14 @@
  *  Product comments CSS
  */
 
+.product-comment-modal .material-icons[data-icon]:before,
+.product-comment-list-item .material-icons[data-icon]:before,
+.product-comments-additional-info .material-icons[data-icon]:before,
+#product-comments-list-header .material-icons[data-icon]:before,
+#product-comments-list-footer .material-icons[data-icon]:before {
+  content: attr(data-icon);
+}
+
 .btn-comment,
 .btn-comment-inverse {
   height: 36px;

--- a/views/js/list-comments.js
+++ b/views/js/list-comments.js
@@ -69,8 +69,8 @@ jQuery(document).ready(function () {
             items: jsonResponse.comments_nb,
             itemsOnPage: jsonResponse.comments_per_page,
             cssStyle: '',
-            prevText: '<i class="material-icons">chevron_left</i>',
-            nextText: '<i class="material-icons">chevron_right</i>',
+            prevText: '<i class="material-icons" data-icon="chevron_left"></i>',
+            nextText: '<i class="material-icons" data-icon="chevron_right"></i>',
             useAnchors: false,
             displayedPages: 2,
             onPageClick: paginateComments

--- a/views/templates/hook/alert-modal.tpl
+++ b/views/templates/hook/alert-modal.tpl
@@ -40,7 +40,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h2>
-          <i class="material-icons {$icon}">{$icon}</i>
+          <i class="material-icons {$icon}" data-icon="{$icon}"></i>
           {$modal_title}
         </h2>
       </div>

--- a/views/templates/hook/confirm-modal.tpl
+++ b/views/templates/hook/confirm-modal.tpl
@@ -48,7 +48,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h2>
-          <i class="material-icons {$icon}">{$icon}</i>
+          <i class="material-icons {$icon}" data-icon="{$icon}"></i>
           {$modal_title}
         </h2>
       </div>

--- a/views/templates/hook/empty-product-comment.tpl
+++ b/views/templates/hook/empty-product-comment.tpl
@@ -26,7 +26,7 @@
 <div id="empty-product-comment" class="product-comment-list-item">
   {if $post_allowed}
     <button class="btn btn-comment btn-comment-big post-product-comment">
-      <i class="material-icons shopping-cart">edit</i>
+      <i class="material-icons shopping-cart" data-icon="edit"></i>
       {l s='Be the first to write your review' d='Modules.Productcomments.Shop'}
     </button>
   {else}

--- a/views/templates/hook/product-additional-info.tpl
+++ b/views/templates/hook/product-additional-info.tpl
@@ -28,7 +28,7 @@
   {if $nb_comments == 0}
     {if $post_allowed}
       <button class="btn btn-comment post-product-comment">
-        <i class="material-icons shopping-cart">edit</i>
+        <i class="material-icons shopping-cart" data-icon="edit"></i>
         {l s='Write your review' d='Modules.Productcomments.Shop'}
       </button>
     {/if}
@@ -36,12 +36,12 @@
     {include file='module:productcomments/views/templates/hook/average-grade-stars.tpl' grade=$average_grade}
     <div class="additional-links">
       <a class="link-comment" href="#product-comments-list-header">
-        <i class="material-icons shopping-cart">chat</i>
+        <i class="material-icons shopping-cart" data-icon="chat"></i>
         {l s='Read user reviews' d='Modules.Productcomments.Shop'} ({$nb_comments})
       </a>
       {if $post_allowed}
         <a class="link-comment post-product-comment" href="#product-comments-list-header">
-          <i class="material-icons shopping-cart">edit</i>
+          <i class="material-icons shopping-cart" data-icon="edit"></i>
           {l s='Write your review' d='Modules.Productcomments.Shop'}
         </a>
       {/if}

--- a/views/templates/hook/product-comment-item-prototype.tpl
+++ b/views/templates/hook/product-comment-item-prototype.tpl
@@ -40,16 +40,16 @@
     <div class="comment-buttons btn-group">
       {if $usefulness_enabled}
         <a class="useful-review">
-          <i class="material-icons thumb_up">thumb_up</i>
+          <i class="material-icons thumb_up" data-icon="thumb_up"></i>
           <span class="useful-review-value">@COMMENT_USEFUL_ADVICES@</span>
         </a>
         <a class="not-useful-review">
-          <i class="material-icons thumb_down">thumb_down</i>
+          <i class="material-icons thumb_down" data-icon="thumb_down"></i>
           <span class="not-useful-review-value">@COMMENT_NOT_USEFUL_ADVICES@</span>
         </a>
       {/if}
       <a class="report-abuse" title="{l s='Report abuse' d='Modules.Productcomments.Shop'}">
-        <i class="material-icons outlined_flag">flag</i>
+        <i class="material-icons outlined_flag" data-icon="flag"></i>
       </a>
     </div>
   </div>

--- a/views/templates/hook/product-comments-list.tpl
+++ b/views/templates/hook/product-comments-list.tpl
@@ -30,7 +30,7 @@
 <div class="row">
   <div class="col-md-12 col-sm-12" id="product-comments-list-header">
     <div class="comments-nb">
-      <i class="material-icons shopping-cart">chat</i>
+      <i class="material-icons" data-icon="chat"></i>
       {l s='Comments' d='Modules.Productcomments.Shop'} ({$nb_comments})
     </div>
     {include file='module:productcomments/views/templates/hook/average-grade-stars.tpl' grade=$average_grade}
@@ -53,7 +53,7 @@
     <div id="product-comments-list-pagination"></div>
     {if $post_allowed && $nb_comments != 0}
       <button class="btn btn-comment btn-comment-big post-product-comment">
-        <i class="material-icons shopping-cart">edit</i>
+        <i class="material-icons" data-icon="edit"></i>
         {l s='Write your review' d='Modules.Productcomments.Shop'}
       </button>
     {/if}
@@ -84,7 +84,7 @@
 
 {* Report abuse error modal *}
 {include file='module:productcomments/views/templates/hook/alert-modal.tpl'
-modal_id='report-comment-post-error'
-modal_title={l s='Your report cannot be sent' d='Modules.Productcomments.Shop'}
-icon='error'
+  modal_id='report-comment-post-error'
+  modal_title={l s='Your report cannot be sent' d='Modules.Productcomments.Shop'}
+  icon='error'
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | To prevent google from indexing material-icons texts move the icon to data-icon and show with a bit of css
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27007
| How to test?  | Check that the material icons show up. remember to force refresh your browser cache to get the latest css file.

Also removed few probably copy paste classes from icon elements.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
