### PR TITLE
Align rating to the left on product list

### DIFF
--- a/views/css/productcomments.css
+++ b/views/css/productcomments.css
@@ -569,6 +569,7 @@
 .product-list-reviews {
   position: absolute;
   top: -26px;
+  left: 0;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The rating is not really aligned on product of product list
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27252.
| How to test?  | You should test this pr with https://github.com/PrestaShop/PrestaShop/pull/27387, this one is just about this element to be aligned to the left of the product

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
