### PR TITLE
Fix hookFilterProductContent to allow hook chain

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -906,7 +906,7 @@ class ProductComments extends Module implements WidgetInterface
     public function hookFilterProductContent(array $params)
     {
         if (empty($params['object']->id)) {
-            return;
+            return $params;
         }
         /** @var ProductCommentRepository $productCommentRepository */
         $productCommentRepository = $this->context->controller->getContainer()->get('product_comment_repository');
@@ -919,6 +919,7 @@ class ProductComments extends Module implements WidgetInterface
             'averageRating' => $averageRating,
             'nbComments' => $nbComments,
         ];
+	return $params;
     }
 
     /**


### PR DESCRIPTION
All hookFilter* functions should always return the following:
    return $params;
Returning $params ensures that other modules in the same hook chain receive the correct $params argument.
To reproduce the bug install an additional module with hookFilterProductContent AFTER the productcomments and run in debug mode.
The following exception appears.
Type error: Argument 3 passed to HookCore::callHookOn() must be of the type array, null given, called in .../classes/Hook.php on line 934

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | All hookFilter* functions should always return the following:  return $params; Returning $params ensures that other modules in the same hook chain receive the correct $params argument.
| Type?         | bug fix / critical
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | To reproduce the bug install an additional module with hookFilterProductContent AFTER the productcomments and run in debug mode.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
