### PR TITLE
TypeError on addCommentGrades in case of empty request

### DIFF
--- a/controllers/front/PostComment.php
+++ b/controllers/front/PostComment.php
@@ -99,7 +99,7 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
 
         //Validate comment
         $errors = array_merge($this->validateComment($productComment), $this->validateCriterions($criterions));
-  
+
         if (!empty($errors)) {
             $this->ajaxRender(
                 json_encode(
@@ -186,6 +186,7 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
 
     /**
      * Valdiate criterions values
+     *
      * @todo manage validation for criterion restricted on categories or products
      *
      * @param array $criterions

--- a/controllers/front/PostComment.php
+++ b/controllers/front/PostComment.php
@@ -60,7 +60,7 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
         $comment_title = Tools::getValue('comment_title');
         $comment_content = Tools::getValue('comment_content');
         $customer_name = Tools::getValue('customer_name');
-        $criterions = Tools::getValue('criterion');
+        $criterions = (array) Tools::getValue('criterion');
 
         /** @var ProductCommentRepository $productCommentRepository */
         $productCommentRepository = $this->context->controller->getContainer()->get('product_comment_repository');
@@ -96,11 +96,10 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
             ->setGuestId($this->context->cookie->id_guest)
             ->setDateAdd(new \DateTime('now', new \DateTimeZone('UTC')))
         ;
-        $entityManager->persist($productComment);
-        $this->addCommentGrades($productComment, $criterions);
 
         //Validate comment
-        $errors = $this->validateComment($productComment);
+        $errors = array_merge($this->validateComment($productComment), $this->validateCriterions($criterions));
+  
         if (!empty($errors)) {
             $this->ajaxRender(
                 json_encode(
@@ -113,6 +112,9 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
 
             return false;
         }
+
+        $entityManager->persist($productComment);
+        $this->addCommentGrades($productComment, $criterions);
 
         $entityManager->flush();
 
@@ -176,6 +178,32 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
                 $errors[] = $this->trans('Customer name cannot be empty', [], 'Modules.Productcomments.Shop');
             } elseif (strlen($productComment->getCustomerName()) > ProductComment::CUSTOMER_NAME_MAX_LENGTH) {
                 $errors[] = $this->trans('Customer name cannot be more than %s characters', [ProductComment::CUSTOMER_NAME_MAX_LENGTH], 'Modules.Productcomments.Shop');
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Valdiate criterions values
+     * @todo manage validation for criterion restricted on categories or products
+     *
+     * @param array $criterions
+     *
+     * @return array
+     */
+    private function validateCriterions(array $criterions)
+    {
+        $errors = [];
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $this->container->get('doctrine.orm.entity_manager');
+        $criterionRepository = $entityManager->getRepository(ProductCommentCriterion::class);
+
+        foreach ($criterions as $criterionId => $grade) {
+            // @todo manage validation for criterion restricted on categories or products
+            $criterion = $criterionRepository->findOneBy(['id' => $criterionId]);
+            if (empty($criterion)) {
+                $errors[] = $this->trans('Criterions not available', [], 'Modules.Productcomments.Shop');
             }
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | URL like /module/productcomments/PostComment?id_product=2 is exposed on html form. <br> Even if the form has a method POST, some bot crawl this URL and error 500 append :<br><pre>Uncaught exception 'TypeError' with message 'Argument 2 passed to <br>ProductCommentsPostCommentModuleFrontController::addCommentGrades() must be of the type array, bool given, called <br>in modules/productcomments/controllers/front/PostComment.php on line 100' <br>in modules/productcomments/controllers/front/PostComment.php:135 <br>in ProductCommentsPostCommentModuleFrontController::addCommentGrades called at modules/productcomments/controllers/front/PostComment.php (100) <br>in ProductCommentsPostCommentModuleFrontController::display called at classes/controller/Controller.php (331) in ControllerCore::run called at /var/www/prod/classes/Dispatcher.php (518) <br>in DispatcherCore::dispatch called at index.php (28)</pre><br>I realized that validation are not done properly and after the persistence of data and criterions are not done.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27534.
| How to test?  | Just call this URL /module/productcomments/PostComment?id_product=2<br>The response code should be 200

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
