### PR TITLE
Prevent use jQuery var before is defined

### DIFF
--- a/views/templates/hook/product-additional-info-quickview.tpl
+++ b/views/templates/hook/product-additional-info-quickview.tpl
@@ -25,10 +25,12 @@
 
 {if $nb_comments != 0}
   <script type="text/javascript">
-    const $ = jQuery;
-    $('#product-quickview-{$product.id}').insertAfter($('.quickview #product-description-short'));
-    $('#product-quickview-{$product.id} .grade-stars').rating({ grade: {$average_grade} });
-    $('#product-quickview-{$product.id} .comments-nb').html('({$nb_comments})');
+    document.addEventListener('DOMContentLoaded', function() {
+      const $ = jQuery;
+      $('#product-quickview-{$product.id}').insertAfter($('.quickview #product-description-short'));
+      $('#product-quickview-{$product.id} .grade-stars').rating({ grade: {$average_grade} });
+      $('#product-quickview-{$product.id} .comments-nb').html('({$nb_comments})');
+    });
   </script>
 
   <div id="product-quickview-{$product.id}" class="product-quickview-review">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In some theme when product has reviews we call `jQuery` var before **core.js** was loaded. In browser we got `ReferenceError: jQuery in not defined` what got next errors `ReferenceError: can't access lexical declaration '$' before initialization`. Now we are sure that `jQuery` exists before we use it!
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Go to any product and add an comment. In backoffice, in productcomments module accept an comment. Refresh page with product and an error will occur.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
