### PR TITLE
Fix hookFilterProductContent to allow hook chain

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -925,7 +925,7 @@ class ProductComments extends Module implements WidgetInterface
      *
      * @param array $params
      *
-     * @return void
+     * @return array
      */
     public function hookFilterProductContent(array $params)
     {

--- a/productcomments.php
+++ b/productcomments.php
@@ -930,7 +930,7 @@ class ProductComments extends Module implements WidgetInterface
     public function hookFilterProductContent(array $params)
     {
         if (empty($params['object']->id)) {
-            return;
+            return $params;
         }
         /** @var ProductCommentRepository $productCommentRepository */
         $productCommentRepository = $this->context->controller->getContainer()->get('product_comment_repository');
@@ -943,6 +943,8 @@ class ProductComments extends Module implements WidgetInterface
             'averageRating' => $averageRating,
             'nbComments' => $nbComments,
         ];
+	    
+        return $params;
     }
 
     /**

--- a/productcomments.php
+++ b/productcomments.php
@@ -943,7 +943,6 @@ class ProductComments extends Module implements WidgetInterface
             'averageRating' => $averageRating,
             'nbComments' => $nbComments,
         ];
-	    
         return $params;
     }
 

--- a/productcomments.php
+++ b/productcomments.php
@@ -943,6 +943,7 @@ class ProductComments extends Module implements WidgetInterface
             'averageRating' => $averageRating,
             'nbComments' => $nbComments,
         ];
+
         return $params;
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | All hookFilter* functions should always return the following: return $params; Returning $params ensures that other modules in the same hook chain receive the correct $params argument.
| Type?         | bug fix / critical
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28342
| How to test?  | To reproduce the bug install an additional module with hookFilterProductContent AFTER the productcomments and run in debug mode.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
