### PR TITLE
Fix to hookFilterProductContent

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -925,7 +925,7 @@ class ProductComments extends Module implements WidgetInterface
      *
      * @param array $params
      *
-     * @return void
+     * @return array
      */
     public function hookFilterProductContent(array $params)
     {

--- a/productcomments.php
+++ b/productcomments.php
@@ -929,20 +929,21 @@ class ProductComments extends Module implements WidgetInterface
      */
     public function hookFilterProductContent(array $params)
     {
-        if (empty($params['object']->id)) {
-            return;
+        if (!empty($params['object']->id)) {
+            /** @var ProductCommentRepository $productCommentRepository */
+            $productCommentRepository = $this->context->controller->getContainer()->get('product_comment_repository');
+
+            $averageRating = $productCommentRepository->getAverageGrade($params['object']->id, (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE'));
+            $nbComments = $productCommentRepository->getCommentsNumber($params['object']->id, (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE'));
+
+            /* @phpstan-ignore-next-line */
+            $params['object']->productComments = [
+                'averageRating' => $averageRating,
+                'nbComments' => $nbComments,
+            ];
         }
-        /** @var ProductCommentRepository $productCommentRepository */
-        $productCommentRepository = $this->context->controller->getContainer()->get('product_comment_repository');
 
-        $averageRating = $productCommentRepository->getAverageGrade($params['object']->id, (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE'));
-        $nbComments = $productCommentRepository->getCommentsNumber($params['object']->id, (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE'));
-
-        /* @phpstan-ignore-next-line */
-        $params['object']->productComments = [
-            'averageRating' => $averageRating,
-            'nbComments' => $nbComments,
-        ];
+        return $params;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | function `hookFilterProductContent` have to return `$params` 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28342.
| How to test?  | Follow steps form issue. No error should occur. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
