### PR TITLE
Adds actionObjectProductCommentAddAfter action hook

### DIFF
--- a/controllers/front/PostComment.php
+++ b/controllers/front/PostComment.php
@@ -118,6 +118,8 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
 
         $entityManager->flush();
 
+        Hook::exec('actionObjectProductCommentAddAfter', ['array' => $productComment->toArray()]);
+
         $this->ajaxRender(
             json_encode(
                 [

--- a/controllers/front/PostComment.php
+++ b/controllers/front/PostComment.php
@@ -118,7 +118,7 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
 
         $entityManager->flush();
 
-        Hook::exec('actionObjectProductCommentAddAfter', ['array' => $productComment->toArray()]);
+        Hook::exec('actionObjectProductCommentAddAfter', ['comment' => $productComment->toArray()]);
 
         $this->ajaxRender(
             json_encode(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This action hook is necessary for this feature: https://github.com/PrestaShop/ps_facetedsearch/pull/569. In PostComment front controller the PostComment entity is being used instead of ObjectModel, so we do not get addAfter event. 
| Type?         | new feature 
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | n/a, developer feature
| How to test?  | after adding a comment from front office hook "actionObjectProductCommentAddAfter" should be executed
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
