### PR TITLE
Simplify Type casting

### DIFF
--- a/ProductComment.php
+++ b/ProductComment.php
@@ -92,8 +92,7 @@ class ProductComment extends ObjectModel
         if (!Validate::isUnsignedId($id_product)) {
             return false;
         }
-        $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');
-	    $id_product = (int) $id_product;
+        $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');	    
         $p = (int) $p;
         $n = (int) $n;
 	    $id_customer = (int) $id_customer;

--- a/ProductComment.php
+++ b/ProductComment.php
@@ -92,7 +92,7 @@ class ProductComment extends ObjectModel
         if (!Validate::isUnsignedId($id_product)) {
             return false;
         }
-        $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');	    
+        $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');
         $p = (int) $p;
         $n = (int) $n;
 	    $id_customer = (int) $id_customer;

--- a/ProductComment.php
+++ b/ProductComment.php
@@ -95,7 +95,7 @@ class ProductComment extends ObjectModel
         $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');
         $p = (int) $p;
         $n = (int) $n;
-	    $id_customer = (int) $id_customer;
+        $id_customer = (int) $id_customer;
         if ($p <= 1) {
             $p = 1;
         }

--- a/ProductComment.php
+++ b/ProductComment.php
@@ -93,8 +93,10 @@ class ProductComment extends ObjectModel
             return false;
         }
         $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');
+	    $id_product = (int) $id_product;
         $p = (int) $p;
         $n = (int) $n;
+	    $id_customer = (int) $id_customer;
         if ($p <= 1) {
             $p = 1;
         }
@@ -102,20 +104,20 @@ class ProductComment extends ObjectModel
             $n = 5;
         }
 
-        $cache_id = 'ProductComment::getByProduct_' . (int) $id_product . '-' . (int) $p . '-' . (int) $n . '-' . (int) $id_customer . '-' . (bool) $validate;
+        $cache_id = 'ProductComment::getByProduct_' . $id_product . '-' . $p . '-' . $n . '-' . $id_customer . '-' . $validate;
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS('
 			SELECT pc.`id_product_comment`,
-			(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_usefulness` pcu WHERE pcu.`id_product_comment` = pc.`id_product_comment` AND pcu.`usefulness` = 1) as total_useful,
-			(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_usefulness` pcu WHERE pcu.`id_product_comment` = pc.`id_product_comment`) as total_advice, ' .
-            ((int) $id_customer ? '(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_usefulness` pcuc WHERE pcuc.`id_product_comment` = pc.`id_product_comment` AND pcuc.id_customer = ' . (int) $id_customer . ') as customer_advice, ' : '') .
-            ((int) $id_customer ? '(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_report` pcrc WHERE pcrc.`id_product_comment` = pc.`id_product_comment` AND pcrc.id_customer = ' . (int) $id_customer . ') as customer_report, ' : '') . '
+			(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_usefulness` pcu WHERE pcu.`id_product_comment` = pc.`id_product_comment` AND pcu.`usefulness` = 1) AS total_useful,
+			(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_usefulness` pcu WHERE pcu.`id_product_comment` = pc.`id_product_comment`) AS total_advice, ' .
+            ($id_customer ? '(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_usefulness` pcuc WHERE pcuc.`id_product_comment` = pc.`id_product_comment` AND pcuc.id_customer = ' . $id_customer . ') AS customer_advice, ' : '') .
+            ($id_customer ? '(SELECT count(*) FROM `' . _DB_PREFIX_ . 'product_comment_report` pcrc WHERE pcrc.`id_product_comment` = pc.`id_product_comment` AND pcrc.id_customer = ' . $id_customer . ') AS customer_report, ' : '') . '
 			IF(c.id_customer, CONCAT(c.`firstname`, \' \',  LEFT(c.`lastname`, 1)), pc.customer_name) customer_name, pc.`content`, pc.`grade`, pc.`date_add`, pc.title
 			  FROM `' . _DB_PREFIX_ . 'product_comment` pc
 			LEFT JOIN `' . _DB_PREFIX_ . 'customer` c ON c.`id_customer` = pc.`id_customer`
-			WHERE pc.`id_product` = ' . (int) ($id_product) . ($validate ? ' AND pc.`validate` = 1' : '') . '
+			WHERE pc.`id_product` = ' . $id_product . ($validate ? ' AND pc.`validate` = 1' : '') . '
 			ORDER BY pc.`date_add` DESC
-			' . ($n ? 'LIMIT ' . (int) (($p - 1) * $n) . ', ' . (int) ($n) : ''));
+			' . ($n ? 'LIMIT ' . (($p - 1) * $n) . ', ' . $n : ''));
             Cache::store($cache_id, $result);
         }
 
@@ -169,8 +171,8 @@ class ProductComment extends ObjectModel
 		LEFT JOIN `' . _DB_PREFIX_ . 'product_comment_grade` pcg ON (pcg.`id_product_comment` = pc.`id_product_comment`)
 		LEFT JOIN `' . _DB_PREFIX_ . 'product_comment_criterion` pcc ON (pcc.`id_product_comment_criterion` = pcg.`id_product_comment_criterion`)
 		LEFT JOIN `' . _DB_PREFIX_ . 'product_comment_criterion_lang` pccl ON (pccl.`id_product_comment_criterion` = pcg.`id_product_comment_criterion`)
-		WHERE pc.`id_product` = ' . (int) $id_product . '
-		AND pccl.`id_lang` = ' . (int) $id_lang .
+		WHERE pc.`id_product` = ' . $id_product . '
+		AND pccl.`id_lang` = ' . $id_lang .
         ($validate ? ' AND pc.`validate` = 1' : ''));
     }
 
@@ -241,12 +243,12 @@ class ProductComment extends ObjectModel
             return false;
         }
         $validate = (bool) Configuration::get('PRODUCT_COMMENTS_MODERATE');
-        $cache_id = 'ProductComment::getCommentNumber_' . (int) $id_product . '-' . $validate;
+        $cache_id = 'ProductComment::getCommentNumber_' . $id_product . '-' . $validate;
         if (!Cache::isStored($cache_id)) {
             $result = (int) Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->getValue('
 			SELECT COUNT(`id_product_comment`) AS "nbr"
 			FROM `' . _DB_PREFIX_ . 'product_comment` pc
-			WHERE `id_product` = ' . (int) ($id_product) . ($validate ? ' AND `validate` = 1' : ''));
+			WHERE `id_product` = ' . $id_product . ($validate ? ' AND `validate` = 1' : ''));
             Cache::store($cache_id, (string) $result);
         }
 
@@ -268,7 +270,7 @@ class ProductComment extends ObjectModel
         $result = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->getRow('
 		SELECT COUNT(pc.`id_product`) AS nbr
 		FROM `' . _DB_PREFIX_ . 'product_comment` pc
-		WHERE `id_product` = ' . (int) ($id_product) . ($validate == '1' ? ' AND `validate` = 1' : '') . '
+		WHERE `id_product` = ' . $id_product . ($validate == '1' ? ' AND `validate` = 1' : '') . '
 		AND `grade` > 0');
 
         return (int) ($result['nbr']);
@@ -348,7 +350,7 @@ class ProductComment extends ObjectModel
         $success = (Db::getInstance()->execute('
 		UPDATE `' . _DB_PREFIX_ . 'product_comment` SET
 		`validate` = ' . (int) $validate . '
-		WHERE `id_product_comment` = ' . (int) $this->id));
+		WHERE `id_product_comment` = ' . $this->id));
 
         Hook::exec('actionObjectProductCommentValidateAfter', ['object' => $this]);
 
@@ -381,7 +383,7 @@ class ProductComment extends ObjectModel
 
         return Db::getInstance()->execute('
 		DELETE FROM `' . _DB_PREFIX_ . 'product_comment_grade`
-		WHERE `id_product_comment` = ' . (int) $id_product_comment);
+		WHERE `id_product_comment` = ' . $id_product_comment);
     }
 
     /**
@@ -397,7 +399,7 @@ class ProductComment extends ObjectModel
 
         return Db::getInstance()->execute('
 		DELETE FROM `' . _DB_PREFIX_ . 'product_comment_report`
-		WHERE `id_product_comment` = ' . (int) $id_product_comment);
+		WHERE `id_product_comment` = ' . $id_product_comment);
     }
 
     /**
@@ -413,7 +415,7 @@ class ProductComment extends ObjectModel
 
         return Db::getInstance()->execute('
 		DELETE FROM `' . _DB_PREFIX_ . 'product_comment_usefulness`
-		WHERE `id_product_comment` = ' . (int) $id_product_comment);
+		WHERE `id_product_comment` = ' . $id_product_comment);
     }
 
     /**

--- a/ProductCommentCriterion.php
+++ b/ProductCommentCriterion.php
@@ -105,7 +105,7 @@ class ProductCommentCriterion extends ObjectModel
 
         return Db::getInstance()->execute('
 			INSERT INTO `' . _DB_PREFIX_ . 'product_comment_criterion_product` (`id_product_comment_criterion`, `id_product`)
-			VALUES(' . (int) $this->id . ',' . (int) $id_product . ')
+			VALUES(' . (int) $this->id . ',' . $id_product . ')
 		');
     }
 
@@ -122,7 +122,7 @@ class ProductCommentCriterion extends ObjectModel
 
         return Db::getInstance()->execute('
 			INSERT INTO `' . _DB_PREFIX_ . 'product_comment_criterion_category` (`id_product_comment_criterion`, `id_category`)
-			VALUES(' . (int) $this->id . ',' . (int) $id_category . ')
+			VALUES(' . (int) $this->id . ',' . $id_category . ')
 		');
     }
 
@@ -145,7 +145,7 @@ class ProductCommentCriterion extends ObjectModel
         return Db::getInstance()->execute('
 		INSERT INTO `' . _DB_PREFIX_ . 'product_comment_grade`
 		(`id_product_comment`, `id_product_comment_criterion`, `grade`) VALUES(
-		' . (int) ($id_product_comment) . ',
+		' . $id_product_comment . ',
 		' . (int) $this->id . ',
 		' . (int) ($grade) . ')');
     }
@@ -169,7 +169,7 @@ class ProductCommentCriterion extends ObjectModel
             $alias = 'ps';
         }
 
-        $cache_id = 'ProductCommentCriterion::getByProduct_' . (int) $id_product . '-' . (int) $id_lang;
+        $cache_id = 'ProductCommentCriterion::getByProduct_' . $id_product . '-' . $id_lang;
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
 				SELECT pcc.`id_product_comment_criterion`, pccl.`name`
@@ -177,12 +177,12 @@ class ProductCommentCriterion extends ObjectModel
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_comment_criterion_lang` pccl
 					ON (pcc.id_product_comment_criterion = pccl.id_product_comment_criterion)
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_comment_criterion_product` pccp
-					ON (pcc.`id_product_comment_criterion` = pccp.`id_product_comment_criterion` AND pccp.`id_product` = ' . (int) $id_product . ')
+					ON (pcc.`id_product_comment_criterion` = pccp.`id_product_comment_criterion` AND pccp.`id_product` = ' . $id_product . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_comment_criterion_category` pccc
 					ON (pcc.`id_product_comment_criterion` = pccc.`id_product_comment_criterion`)
 				LEFT JOIN `' . _DB_PREFIX_ . 'product' . $table . '` ' . $alias . '
-					ON (' . $alias . '.id_category_default = pccc.id_category AND ' . $alias . '.id_product = ' . (int) $id_product . ')
-				WHERE pccl.`id_lang` = ' . (int) ($id_lang) . '
+					ON (' . $alias . '.id_category_default = pccc.id_category AND ' . $alias . '.id_product = ' . $id_product . ')
+				WHERE pccl.`id_lang` = ' . $id_lang . '
 				AND (
 					pccp.id_product IS NOT NULL
 					OR ps.id_product IS NOT NULL
@@ -212,7 +212,7 @@ class ProductCommentCriterion extends ObjectModel
 			SELECT pcc.`id_product_comment_criterion`, pcc.id_product_comment_criterion_type, pccl.`name`, pcc.active
 			FROM `' . _DB_PREFIX_ . 'product_comment_criterion` pcc
 			JOIN `' . _DB_PREFIX_ . 'product_comment_criterion_lang` pccl ON (pcc.id_product_comment_criterion = pccl.id_product_comment_criterion)
-			WHERE pccl.`id_lang` = ' . (int) $id_lang . ($active ? ' AND active = 1' : '') . ($type ? ' AND id_product_comment_criterion_type = ' . (int) $type : '') . '
+			WHERE pccl.`id_lang` = ' . $id_lang . ($active ? ' AND active = 1' : '') . ($type ? ' AND id_product_comment_criterion_type = ' . (int) $type : '') . '
 			ORDER BY pccl.`name` ASC';
         $criterions = Db::getInstance()->executeS($sql);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | 1. Assign $id_xyz = (int) $id_xyz once at top, instead of using (int) $id_xyz throughout the function <br/> 2. if Validate::isUnsignedId($id_xyz ) then there is no need to type cast (int) ($id_xyz)
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28879.
| How to test?  | Check BO Configuration form and FO Product page and Category page where ProductComments is used.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
