### PR TITLE
Remove unused ProductCriterion.php file

### DIFF
--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -5,8 +5,7 @@ parameters:
     # From PHPStan 0.12, paths to check are relative to the neon file
     - ../../productcomments.php
     - ../../ProductComment.php
-    - ../../ProductCommentCriterion.php
-    - ../../ProductCriterion.php
+    - ../../ProductCommentCriterion.php    
     - ../../controllers/
     - ../../src/
     - ../../upgrade/


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | ProductCriterion.php is not used anywhere. The correct and working version of it is ProductCommentCriterion.php
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Find 'ProductCriterion.php' phrase in the whole PrestaShop folder, it only appears in tests/phpstan/phpstan.neon
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
