### PR TITLE
Fix rating is not displayed in the second Quick view

### DIFF
--- a/views/templates/hook/product-additional-info-quickview.tpl
+++ b/views/templates/hook/product-additional-info-quickview.tpl
@@ -24,8 +24,7 @@
  *}
 
 {if $nb_comments != 0}
-  <script type="text/javascript">
-    const $ = jQuery;
+  <script type="text/javascript">    
     $('#product-quickview-{$product.id}').insertAfter($('.quickview #product-description-short'));
     $('#product-quickview-{$product.id} .grade-stars').rating({ grade: {$average_grade} });
     $('#product-quickview-{$product.id} .comments-nb').html('({$nb_comments})');


### PR DESCRIPTION
Product QuickView modal is called from a Product List context, that already has **productcomments.js** loaded with 
`const $ = jQuery;`
So we do not need this command in **quickview.tpl**.
Furthermore, this command creates `SyntaxError: redeclaration of const $` that breaks rating of the second quickview.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read above description and Check related issue
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27845
| How to test?  | Check related issue
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
