### PR TITLE
Fix jQuery event shorthand is deprecated - change, submit, hover

### DIFF
--- a/views/js/jquery.rating.plugin.js
+++ b/views/js/jquery.rating.plugin.js
@@ -93,7 +93,7 @@ jQuery.fn.rating = function(generalOptions) {
             }
           });
         });
-        newStar.click(function selectGrade() {
+        newStar.on('click', function selectGrade() {
           var selectedGrade = $(this).data('grade');
           ratingInput.val(selectedGrade);
         });

--- a/views/js/jquery.rating.plugin.js
+++ b/views/js/jquery.rating.plugin.js
@@ -100,7 +100,7 @@ jQuery.fn.rating = function(generalOptions) {
         fullStars.append(newStar);
       }
 
-      fullStars.mouseenter(function(){}).mouseleave(displayInteractiveGrade);
+      fullStars.on('mouseenter', function(){}).on('mouseleave', displayInteractiveGrade);
       displayInteractiveGrade();
     }
 

--- a/views/js/jquery.rating.plugin.js
+++ b/views/js/jquery.rating.plugin.js
@@ -67,7 +67,7 @@ jQuery.fn.rating = function(generalOptions) {
       ratingInput = $('<input type="number" name="'+componentOptions.input+'" id="'+componentOptions.input+'" />');
       ratingInput.val(ratingValue);
       ratingInput.css('display', 'none');
-      ratingInput.change(displayInteractiveGrade);
+      ratingInput.on('change', displayInteractiveGrade);
       $ratingComponent.append(ratingInput);
       initInteractiveGrade();
     } else {
@@ -81,7 +81,7 @@ jQuery.fn.rating = function(generalOptions) {
       for (var i = minValue; i <= maxValue; ++i) {
         newStar = emptyStar.clone();
         newStar.data('grade', i);
-        newStar.hover(function overStar() {
+        newStar.on('mouseenter mouseleave', function overStar() {
           var overIndex = $('.star', fullStars).index($(this));
           $('.star', fullStars).each(function overStars() {
             $(this).removeClass('star-on');
@@ -100,7 +100,7 @@ jQuery.fn.rating = function(generalOptions) {
         fullStars.append(newStar);
       }
 
-      fullStars.hover(function(){}, displayInteractiveGrade);
+      fullStars.mouseenter(function(){}).mouseleave(displayInteractiveGrade);
       displayInteractiveGrade();
     }
 

--- a/views/js/post-comment.js
+++ b/views/js/post-comment.js
@@ -65,7 +65,7 @@ jQuery(document).ready(function () {
     $('#post-product-comment-form input[type="text"]').removeClass('valid error');
     $('#post-product-comment-form textarea').val('');
     $('#post-product-comment-form textarea').removeClass('valid error');
-    $('#post-product-comment-form .criterion-rating input').val(3).change();
+    $('#post-product-comment-form .criterion-rating input').val(3).trigger('change');
   }
 
   function initCommentModal() {
@@ -75,7 +75,7 @@ jQuery(document).ready(function () {
       showPostCommentModal();
     });
 
-    $('#post-product-comment-form').submit(submitCommentForm);
+    $('#post-product-comment-form').on('submit', submitCommentForm);
   }
 
   function submitCommentForm(event) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `change`, `hover,` and `submit` event shorthand are deprecated in jQuery 3. jquery-migrate keep warnings about them before fix automatically.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/Prestashop#28935
| How to test?  | Check web browser console of Product page before and after PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
