### PR TITLE
Remove microdata from product miniatures

### DIFF
--- a/views/templates/hook/product-list-reviews.tpl
+++ b/views/templates/hook/product-list-reviews.tpl
@@ -29,11 +29,3 @@
   <div class="grade-stars small-stars"></div>
   <div class="comments-nb"></div>
 </div>
-
-{if $nb_comments != 0}
-{* Rich snippet rating is displayed via php/smarty meaning it will be cached (for example on homepage) *}
-<div itemprop="aggregateRating" itemtype="http://schema.org/AggregateRating" itemscope>
-  <meta itemprop="reviewCount" content="{$nb_comments}" />
-  <meta itemprop="ratingValue" content="{$average_grade}" />
-</div>
-{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Microdata is not useful on listing pages because it is already present on product pages in JSON-LD. 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30543
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
