### PR TITLE
Fix htmlentities by Tools::htmlentitiesUTF8

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -698,7 +698,7 @@ class ProductComments extends Module implements WidgetInterface
      */
     public function renderAuthorName($value, $row)
     {
-        $value = htmlentities($value);
+        $value = Tools::htmlentitiesUTF8($value);
         if (!empty($row['customer_id'])) {
             $linkToCustomerProfile = $this->context->link->getAdminLink('AdminCustomers', false, [], [
                 'id_customer' => $row['customer_id'],

--- a/productcomments.php
+++ b/productcomments.php
@@ -698,7 +698,7 @@ class ProductComments extends Module implements WidgetInterface
      */
     public function renderAuthorName($value, $row)
     {
-        $value = Tools::htmlentitiesUTF8($value);
+        $value = Tools::htmlentitiesUTF8($value, ENT_QUOTES);
         if (!empty($row['customer_id'])) {
             $linkToCustomerProfile = $this->context->link->getAdminLink('AdminCustomers', false, [], [
                 'id_customer' => $row['customer_id'],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | To be sure to escape simple quote in PHP 8.0 it's better to .
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#30573
| How to test?  | Add an author name with a simple quote.<br>It should be replace by the corresponding html entity.
