### PR TITLE
Remove unneeded code

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -270,9 +270,9 @@ class ProductComments extends Module implements WidgetInterface
     }
 
     public function getContent()
-    {        
+    {
         include_once dirname(__FILE__) . '/ProductComment.php';
-        include_once dirname(__FILE__) . '/ProductCommentCriterion.php';        
+        include_once dirname(__FILE__) . '/ProductCommentCriterion.php';
 
         $this->_html = '';
         if (Tools::isSubmit('updateproductcommentscriterion')) {
@@ -431,7 +431,6 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderModerateLists()
     {
-        //require_once dirname(__FILE__) . '/ProductComment.php';
         $return = null;
 
         if (Configuration::get('PRODUCT_COMMENTS_MODERATE')) {
@@ -532,8 +531,6 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderCriterionList()
     {
-        //include_once dirname(__FILE__) . '/ProductCommentCriterion.php';
-
         $criterions = ProductCommentCriterion::getCriterions($this->context->language->id, false, false);
 
         $fields_list = [
@@ -577,8 +574,6 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderCommentsList()
     {
-        //require_once dirname(__FILE__) . '/ProductComment.php';
-
         $fields_list = $this->getStandardFieldList();
 
         $helper = new HelperList();

--- a/productcomments.php
+++ b/productcomments.php
@@ -438,12 +438,7 @@ class ProductComments extends Module implements WidgetInterface
 
             $fields_list = $this->getStandardFieldList();
 
-            if (version_compare(_PS_VERSION_, '1.6', '<')) {
-                $return .= '<h1>' . $this->trans('Reviews waiting for approval', [], 'Modules.Productcomments.Admin') . '</h1>';
-                $actions = ['enable', 'delete'];
-            } else {
-                $actions = ['approve', 'delete'];
-            }
+            $actions = ['approve', 'delete'];
 
             $helper = new HelperList();
             $helper->list_id = 'form-productcomments-moderate-list';

--- a/productcomments.php
+++ b/productcomments.php
@@ -723,14 +723,7 @@ class ProductComments extends Module implements WidgetInterface
             }
         }
 
-        if (version_compare(_PS_VERSION_, '1.6', '<')) {
-            $field_category_tree = [
-                'type' => 'categories_select',
-                'name' => 'categoryBox',
-                'label' => $this->trans('Criterion will be restricted to the following categories', [], 'Modules.Productcomments.Admin'),
-                'category_tree' => $this->initCategoriesAssociation(null, $id_criterion),
-            ];
-        } else {
+	{
             $field_category_tree = [
                 'type' => 'categories',
                 'label' => $this->trans('Criterion will be restricted to the following categories', [], 'Modules.Productcomments.Admin'),

--- a/productcomments.php
+++ b/productcomments.php
@@ -723,38 +723,36 @@ class ProductComments extends Module implements WidgetInterface
             }
         }
 
-	{
-            $field_category_tree = [
-                'type' => 'categories',
-                'label' => $this->trans('Criterion will be restricted to the following categories', [], 'Modules.Productcomments.Admin'),
-                'name' => 'categoryBox',
-                'desc' => $this->trans('Mark the boxes of categories to which this criterion applies.', [], 'Modules.Productcomments.Admin'),
-                'tree' => [
-                    'use_search' => false,
-                    'id' => 'categoryBox',
-                    'use_checkbox' => true,
-                    'selected_categories' => $selected_categories,
+        $field_category_tree = [
+            'type' => 'categories',
+            'label' => $this->trans('Criterion will be restricted to the following categories', [], 'Modules.Productcomments.Admin'),
+            'name' => 'categoryBox',
+            'desc' => $this->trans('Mark the boxes of categories to which this criterion applies.', [], 'Modules.Productcomments.Admin'),
+            'tree' => [
+                'use_search' => false,
+                'id' => 'categoryBox',
+                'use_checkbox' => true,
+                'selected_categories' => $selected_categories,
+            ],
+            //retro compat 1.5 for category tree
+            'values' => [
+                'trads' => [
+                    'Root' => Category::getTopCategory(),
+                    'selected' => $this->trans('Selected', [], 'Modules.Productcomments.Admin'),
+                    'Collapse All' => $this->trans('Collapse All', [], 'Modules.Productcomments.Admin'),
+                    'Expand All' => $this->trans('Expand All', [], 'Modules.Productcomments.Admin'),
+                    'Check All' => $this->trans('Check All', [], 'Modules.Productcomments.Admin'),
+                    'Uncheck All' => $this->trans('Uncheck All', [], 'Modules.Productcomments.Admin'),
                 ],
-                //retro compat 1.5 for category tree
-                'values' => [
-                    'trads' => [
-                        'Root' => Category::getTopCategory(),
-                        'selected' => $this->trans('Selected', [], 'Modules.Productcomments.Admin'),
-                        'Collapse All' => $this->trans('Collapse All', [], 'Modules.Productcomments.Admin'),
-                        'Expand All' => $this->trans('Expand All', [], 'Modules.Productcomments.Admin'),
-                        'Check All' => $this->trans('Check All', [], 'Modules.Productcomments.Admin'),
-                        'Uncheck All' => $this->trans('Uncheck All', [], 'Modules.Productcomments.Admin'),
-                    ],
-                    'selected_cat' => $selected_categories,
-                    'input_name' => 'categoryBox[]',
-                    'use_radio' => false,
-                    'use_search' => false,
-                    'disabled_categories' => [],
-                    'top_category' => Category::getTopCategory(),
-                    'use_context' => true,
-                ],
-            ];
-        }
+                'selected_cat' => $selected_categories,
+                'input_name' => 'categoryBox[]',
+                'use_radio' => false,
+                'use_search' => false,
+                'disabled_categories' => [],
+                'top_category' => Category::getTopCategory(),
+                'use_context' => true,
+            ],
+        ];
 
         $fields_form_1 = [
             'form' => [

--- a/productcomments.php
+++ b/productcomments.php
@@ -270,9 +270,9 @@ class ProductComments extends Module implements WidgetInterface
     }
 
     public function getContent()
-    {
+    {        
         include_once dirname(__FILE__) . '/ProductComment.php';
-        include_once dirname(__FILE__) . '/ProductCommentCriterion.php';
+        include_once dirname(__FILE__) . '/ProductCommentCriterion.php';        
 
         $this->_html = '';
         if (Tools::isSubmit('updateproductcommentscriterion')) {
@@ -431,7 +431,7 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderModerateLists()
     {
-        require_once dirname(__FILE__) . '/ProductComment.php';
+        //require_once dirname(__FILE__) . '/ProductComment.php';
         $return = null;
 
         if (Configuration::get('PRODUCT_COMMENTS_MODERATE')) {
@@ -532,7 +532,7 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderCriterionList()
     {
-        include_once dirname(__FILE__) . '/ProductCommentCriterion.php';
+        //include_once dirname(__FILE__) . '/ProductCommentCriterion.php';
 
         $criterions = ProductCommentCriterion::getCriterions($this->context->language->id, false, false);
 
@@ -577,7 +577,7 @@ class ProductComments extends Module implements WidgetInterface
 
     public function renderCommentsList()
     {
-        require_once dirname(__FILE__) . '/ProductComment.php';
+        //require_once dirname(__FILE__) . '/ProductComment.php';
 
         $fields_list = $this->getStandardFieldList();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | 1. Three functions: renderModerateLists, renderCriterionList, renderCommentsList are only called in productcomment.php [getContent](https://github.com/PrestaShop/productcomments/blob/v5.0.2/productcomments.php#L251-L265) that already has 2 require_once at top, so there is no need to require_once again in render functions. <br> 2. The minimum PS_VERSION of version 5.0.2 is [1.7.6](https://github.com/PrestaShop/productcomments/blob/v5.0.2/productcomments.php#L58), so there is no need to check for PS 1.6 and prior.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No issue at all. Just beautify the code.
| How to test?  | Apply the PR changes then check module in BO and FO to make sure it works as usual.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
