### PR TITLE
Fix removing previous module files in PHPStan tests

### DIFF
--- a/tests/phpstan.sh
+++ b/tests/phpstan.sh
@@ -14,7 +14,7 @@ docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/presta
 # Clear previous instance of the module in the PrestaShop volume
 echo "Clear previous module"
 
-docker exec -t temp-ps rm -rf /var/www/html/modules/productcomments
+docker exec -t --user root temp-ps sh -c 'find /var/www/html/modules/productcomments -type f -exec rm {} +'
 
 # Run a container for PHPStan, having access to the module content and PrestaShop sources.
 # This tool is outside the composer.json because of the compatibility with PHP 5.6


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The previous way of removing the directory didn't work correctly.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | This is just a copy of https://github.com/PrestaShop/blockreassurance/pull/594
| How to test?  | CI is 🟢 (with less random php-test `rm -rf` failures :)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
