### PR TITLE
Mark deprecated functions since v4.0.0 and v6.0.0

### DIFF
--- a/ProductComment.php
+++ b/ProductComment.php
@@ -438,7 +438,7 @@ class ProductComment extends ObjectModel
      * Report comment
      *
      * @return bool
-     * 
+     *
      * @deprecated 4.0.0 - migrated to controllers/front/ReportComment and src/Entity/ProductCommentReport
      */
     public static function reportComment($id_product_comment, $id_customer)
@@ -452,7 +452,7 @@ class ProductComment extends ObjectModel
      * Comment already report
      *
      * @return bool
-     * 
+     *
      * @deprecated 4.0.0 - migrated to controllers/front/ReportComment and src/Entity/ProductCommentReport
      */
     public static function isAlreadyReport($id_product_comment, $id_customer)
@@ -468,7 +468,7 @@ class ProductComment extends ObjectModel
      * Set comment usefulness
      *
      * @return bool
-     * 
+     *
      * @deprecated 4.0.0 - migrated to controllers/front/UpdateCommentUsefulness and src/Entity/ProductCommentUsefulness
      */
     public static function setCommentUsefulness($id_product_comment, $usefulness, $id_customer)
@@ -482,7 +482,7 @@ class ProductComment extends ObjectModel
      * Usefulness already set
      *
      * @return bool
-     * 
+     *
      * @deprecated 4.0.0 - migrated to controllers/front/UpdateCommentUsefulness and src/Entity/ProductCommentUsefulness
      */
     public static function isAlreadyUsefulness($id_product_comment, $id_customer)

--- a/ProductComment.php
+++ b/ProductComment.php
@@ -438,6 +438,8 @@ class ProductComment extends ObjectModel
      * Report comment
      *
      * @return bool
+     * 
+     * @deprecated 4.0.0 - migrated to controllers/front/ReportComment and src/Entity/ProductCommentReport
      */
     public static function reportComment($id_product_comment, $id_customer)
     {
@@ -450,6 +452,8 @@ class ProductComment extends ObjectModel
      * Comment already report
      *
      * @return bool
+     * 
+     * @deprecated 4.0.0 - migrated to controllers/front/ReportComment and src/Entity/ProductCommentReport
      */
     public static function isAlreadyReport($id_product_comment, $id_customer)
     {
@@ -464,6 +468,8 @@ class ProductComment extends ObjectModel
      * Set comment usefulness
      *
      * @return bool
+     * 
+     * @deprecated 4.0.0 - migrated to controllers/front/UpdateCommentUsefulness and src/Entity/ProductCommentUsefulness
      */
     public static function setCommentUsefulness($id_product_comment, $usefulness, $id_customer)
     {
@@ -476,6 +482,8 @@ class ProductComment extends ObjectModel
      * Usefulness already set
      *
      * @return bool
+     * 
+     * @deprecated 4.0.0 - migrated to controllers/front/UpdateCommentUsefulness and src/Entity/ProductCommentUsefulness
      */
     public static function isAlreadyUsefulness($id_product_comment, $id_customer)
     {

--- a/ProductCommentCriterion.php
+++ b/ProductCommentCriterion.php
@@ -48,7 +48,7 @@ class ProductCommentCriterion extends ObjectModel
     ];
 
     /**
-     * @deprecated 6.0.0
+     * @deprecated 6.0.0 - migrated to src/Repository/ProductCommentCriterionRepository
      */
     public function delete()
     {
@@ -100,7 +100,7 @@ class ProductCommentCriterion extends ObjectModel
      *
      * @return bool succeed
      * 
-     * @deprecated 6.0.0
+     * @deprecated 6.0.0 - migrated to src/Repository/ProductCommentCriterionRepository
      */
     public function addProduct($id_product)
     {
@@ -119,7 +119,7 @@ class ProductCommentCriterion extends ObjectModel
      *
      * @return bool succeed
      * 
-     * @deprecated 6.0.0
+     * @deprecated 6.0.0 - migrated to src/Repository/ProductCommentCriterionRepository
      */
     public function addCategory($id_category)
     {

--- a/ProductCommentCriterion.php
+++ b/ProductCommentCriterion.php
@@ -99,7 +99,7 @@ class ProductCommentCriterion extends ObjectModel
      * Link a Comment Criterion to a product
      *
      * @return bool succeed
-     * 
+     *
      * @deprecated 6.0.0 - migrated to src/Repository/ProductCommentCriterionRepository
      */
     public function addProduct($id_product)
@@ -118,7 +118,7 @@ class ProductCommentCriterion extends ObjectModel
      * Link a Comment Criterion to a category
      *
      * @return bool succeed
-     * 
+     *
      * @deprecated 6.0.0 - migrated to src/Repository/ProductCommentCriterionRepository
      */
     public function addCategory($id_category)

--- a/ProductCommentCriterion.php
+++ b/ProductCommentCriterion.php
@@ -47,6 +47,9 @@ class ProductCommentCriterion extends ObjectModel
         ],
     ];
 
+    /**
+     * @deprecated 6.0.0
+     */
     public function delete()
     {
         if (!parent::delete()) {
@@ -96,6 +99,8 @@ class ProductCommentCriterion extends ObjectModel
      * Link a Comment Criterion to a product
      *
      * @return bool succeed
+     * 
+     * @deprecated 6.0.0
      */
     public function addProduct($id_product)
     {
@@ -113,6 +118,8 @@ class ProductCommentCriterion extends ObjectModel
      * Link a Comment Criterion to a category
      *
      * @return bool succeed
+     * 
+     * @deprecated 6.0.0
      */
     public function addCategory($id_category)
     {

--- a/upgrade/install-6.0.3.php
+++ b/upgrade/install-6.0.3.php
@@ -27,7 +27,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-function upgrade_module_6_0_1($object)
+function upgrade_module_6_0_3($object)
 {
     return Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'product_comment` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci')
         && Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'product_comment_criterion` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Some deprecated functions in 2 unused classes are not marked as Deprecated yet. This PR do it. <br>Upgrade script 6.0.3 need function `upgrade_module_6_0_3` not upgrade_module_6_0_1 inside 
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No issue at all. Just mark deprecated functions to delete them in the next major version.
| How to test?  | Please check the description beside @Deprecated.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
