### PR TITLE
If user mistakenly attempts to delete a comment, fail gracefully

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -208,7 +208,7 @@ class ProductComments extends Module implements WidgetInterface
         } elseif (Tools::isSubmit('deleteproductcomments')) {
             $comment = $commentRepository->find($id_product_comment);
 
-            if ($comment ===  null) {
+            if ($comment === null) {
                 $this->_html .= $this->displayError($this->trans('The comment cannot be deleted', [], 'Modules.Productcomments.Admin'));
             } else {
                 $commentRepository->delete($comment);

--- a/productcomments.php
+++ b/productcomments.php
@@ -207,7 +207,13 @@ class ProductComments extends Module implements WidgetInterface
             $commentRepository->deleteReports($id_product_comment);
         } elseif (Tools::isSubmit('deleteproductcomments')) {
             $comment = $commentRepository->find($id_product_comment);
-            $commentRepository->delete($comment);
+
+            if ($comment ===  null) {
+                $this->_html .= $this->displayError($this->trans('The comment cannot be deleted', [], 'Modules.Productcomments.Admin'));
+            } else {
+                $commentRepository->delete($comment);
+                Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
+            }
         } elseif (Tools::isSubmit('submitEditCriterion')) {
             $criterion = $criterionRepository->findRelation((int) Tools::getValue('id_product_comment_criterion'));
             $criterion->setType((int) Tools::getValue('id_product_comment_criterion_type'));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes 2 issues described in https://github.com/PrestaShop/PrestaShop/issues/34512 : missing redirect after successfull deletion of a comment, and missing handling of bad input when delete is called on a comment that does not exist
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/34512
| How to test?  | Please follow the ticket instructions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
