### PR TITLE
Replace manual lang process by standard DoctrineRelation and SymfonyFormData

### DIFF
--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -1,2 +1,18 @@
 imports:
   - { resource: ../common.yml }
+
+services:
+    product_comment_criterion_form_data_provider:
+        class: 'PrestaShop\Module\ProductComment\Form\ProductCommentCriterionFormDataProvider'
+        public: true
+        arguments:
+            - '@product_comment_criterion_repository'
+            - '@prestashop.core.admin.lang.repository'
+            
+    product_comment_criterion_form_data_handler:
+        class: 'PrestaShop\Module\ProductComment\Form\ProductCommentCriterionFormDataHandler'
+        public: true
+        arguments:
+            - '@product_comment_criterion_repository'
+            - '@prestashop.core.admin.lang.repository'
+            - '@doctrine.orm.default_entity_manager'

--- a/productcomments.php
+++ b/productcomments.php
@@ -169,8 +169,10 @@ class ProductComments extends Module implements WidgetInterface
     protected function _postProcess()
     {
         $id_product_comment = (int) Tools::getValue('id_product_comment');
+        $id_product_comment_criterion = (int) Tools::getValue('id_product_comment_criterion');
         $commentRepository = $this->get('product_comment_repository');
         $criterionRepository = $this->get('product_comment_criterion_repository');
+        $criterionFormHandler = $this->get('product_comment_criterion_form_data_handler');
 
         if (Tools::isSubmit('submitModerate')) {
             $errors = [];
@@ -215,7 +217,12 @@ class ProductComments extends Module implements WidgetInterface
                 Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
             }
         } elseif (Tools::isSubmit('submitEditCriterion')) {
-            $criterion = $criterionRepository->findRelation((int) Tools::getValue('id_product_comment_criterion'));
+            if ($id_product_comment_criterion > 0) {
+                $criterion = $criterionRepository->find($id_product_comment_criterion);
+            } else {
+                $criterion = new ProductCommentCriterion();
+            }
+
             $criterion->setType((int) Tools::getValue('id_product_comment_criterion_type'));
             $criterion->setActive(Tools::getValue('active'));
 
@@ -224,7 +231,12 @@ class ProductComments extends Module implements WidgetInterface
             foreach ($languages as $key => $value) {
                 $name[$value['id_lang']] = Tools::getValue('name_' . $value['id_lang']);
             }
-            $criterion->setNames($name);
+
+            if ($id_product_comment_criterion > 0) {
+                $criterionFormHandler->updateLangs($criterion, $name);
+            } else {
+                $criterionFormHandler->createLangs($criterion, $name);
+            }
 
             if (!$criterion->isValid()) {
                 $this->_html .= $this->displayError($this->trans('The criterion cannot be saved', [], 'Modules.Productcomments.Admin'));
@@ -238,14 +250,18 @@ class ProductComments extends Module implements WidgetInterface
                 }
             }
         } elseif (Tools::isSubmit('deleteproductcommentscriterion')) {
-            $criterion = $criterionRepository->findRelation((int) Tools::getValue('id_product_comment_criterion'));
+            $criterion = $criterionRepository->find($id_product_comment_criterion);
             if ($criterionRepository->delete($criterion)) {
-                $this->_html .= $this->displayConfirmation($this->trans('Criterion deleted', [], 'Modules.Productcomments.Admin'));
+                Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
+            } else {
+                $this->_html .= $this->displayError($this->trans('Criterion cannot be deleted', [], 'Modules.Productcomments.Admin'));
             }
         } elseif (Tools::isSubmit('statusproductcommentscriterion')) {
-            $criterion = $criterionRepository->findRelation((int) Tools::getValue('id_product_comment_criterion'));
+            $criterion = $criterionRepository->find($id_product_comment_criterion);
             $criterion->setActive(!$criterion->isActive());
-            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name, 'tab_module' => $this->tab, 'conf' => 4, 'module_name' => $this->name]));
+            $criterionRepository->updateGeneral($criterion);
+
+            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]));
         } elseif ($id_product_comment = (int) Tools::getValue('approveComment')) {
             $comment = $commentRepository->find($id_product_comment);
             $commentRepository->validate($comment, 1);
@@ -602,16 +618,22 @@ class ProductComments extends Module implements WidgetInterface
         ];
     }
 
-    public function getCriterionFieldsValues($id = 0)
+    public function getCriterionFieldsValues(int $id = 0)
     {
         $criterionRepos = $this->get('product_comment_criterion_repository');
-        $criterion = $criterionRepos->findRelation($id);
+        $criterionFormProvider = $this->get('product_comment_criterion_form_data_provider');
+
+        if ($id > 0) {
+            $criterionData = $criterionFormProvider->getData($id);
+        } else {
+            $criterionData = $criterionFormProvider->getDefaultData();
+        }
 
         return [
-            'name' => $criterion->getNames(),
-            'id_product_comment_criterion_type' => $criterion->getType(),
-            'active' => $criterion->isActive(),
-            'id_product_comment_criterion' => $criterion->getId(),
+            'name' => $criterionData['name'],
+            'id_product_comment_criterion_type' => $criterionData['type'],
+            'active' => $criterionData['active'],
+            'id_product_comment_criterion' => $id,
         ];
     }
 
@@ -702,7 +724,7 @@ class ProductComments extends Module implements WidgetInterface
 
         $criterionRepository = $this->get('product_comment_criterion_repository');
 
-        $criterion = $criterionRepository->findRelation($id_criterion);
+        $criterion = $criterionRepository->find($id_criterion);
         $selected_categories = $criterionRepository->getCategories($id_criterion);
 
         $product_table_values = Product::getSimpleProducts($this->langId);

--- a/src/Entity/ProductCommentCriterionLang.php
+++ b/src/Entity/ProductCommentCriterionLang.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\ProductComment\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use PrestaShopBundle\Entity\Lang;
+
+/**
+ * @ORM\Table()
+ *
+ * @ORM\Entity()
+ */
+class ProductCommentCriterionLang
+{
+    /**
+     * @var ProductCommentCriterion
+     *
+     * @ORM\Id
+     *
+     * @ORM\ManyToOne(targetEntity="PrestaShop\Module\ProductComment\Entity\ProductCommentCriterion", inversedBy="criterionLangs")
+     *
+     * @ORM\JoinColumn(name="id_product_comment_criterion", referencedColumnName="id_product_comment_criterion", nullable=false)
+     */
+    private $productcommentcriterion;
+
+    /**
+     * @var Lang
+     *
+     * @ORM\Id
+     *
+     * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
+     *
+     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE")
+     */
+    private $lang;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", nullable=false)
+     */
+    private $name;
+
+    /**
+     * @return ProductCommentCriterion
+     */
+    public function getProductCommentCriterion()
+    {
+        return $this->productcommentcriterion;
+    }
+
+    public function setProductCommentCriterion(ProductCommentCriterion $productcommentcriterion): self
+    {
+        $this->productcommentcriterion = $productcommentcriterion;
+
+        return $this;
+    }
+
+    /**
+     * @return Lang
+     */
+    public function getLang()
+    {
+        return $this->lang;
+    }
+
+    /**
+     * @param Lang $lang
+     */
+    public function setLang(Lang $lang): self
+    {
+        $this->lang = $lang;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/Form/ProductCommentCriterionFormDataHandler.php
+++ b/src/Form/ProductCommentCriterionFormDataHandler.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\ProductComment\Form;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\Module\ProductComment\Entity\ProductCommentCriterion;
+use PrestaShop\Module\ProductComment\Entity\ProductCommentCriterionLang;
+use PrestaShop\Module\ProductComment\Repository\ProductCommentCriterionRepository;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandlerInterface;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+
+class ProductCommentCriterionFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var ProductCommentCriterionRepository
+     */
+    private $pccriterionRepository;
+
+    /**
+     * @var LangRepository
+     */
+    private $langRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @param ProductCommentCriterionRepository $pccriterionRepository
+     * @param LangRepository $langRepository
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(
+        ProductCommentCriterionRepository $pccriterionRepository,
+        LangRepository $langRepository,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->pccriterionRepository = $pccriterionRepository;
+        $this->langRepository = $langRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $data)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($id, array $data)
+    {
+    }
+
+    /**
+     * @param ProductCommentCriterion $pccriterion
+     * @param array $pcc_languages
+     *
+     * @todo migrate this temporary function to above standard function create
+     */
+    public function createLangs($pccriterion, $pcc_languages): void
+    {
+        foreach ($pcc_languages as $langId => $langContent) {
+            $lang = $this->langRepository->find($langId);
+            $pccriterionLang = new ProductCommentCriterionLang();
+            $pccriterionLang
+                ->setLang($lang)
+                ->setName($langContent)
+            ;
+            $pccriterion->addCriterionLang($pccriterionLang);
+        }
+
+        $this->entityManager->persist($pccriterion);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param ProductCommentCriterion $pccriterion
+     * @param array $pcc_languages
+     *
+     * @todo migrate this temporary function to above standard function update
+     */
+    public function updateLangs($pccriterion, $pcc_languages): void
+    {
+        foreach ($pcc_languages as $langId => $langContent) {
+            $lang = $this->langRepository->find($langId);
+            $pccriterionLang = $pccriterion->getCriterionLangByLangId($langId);
+            if (null === $pccriterionLang) {
+                continue;
+            }
+            $pccriterionLang
+                ->setName($langContent)
+            ;
+        }
+
+        $this->entityManager->persist($pccriterion);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Form/ProductCommentCriterionFormDataProvider.php
+++ b/src/Form/ProductCommentCriterionFormDataProvider.php
@@ -74,7 +74,6 @@ class ProductCommentCriterionFormDataProvider implements FormDataProviderInterfa
     {
         $default_name = [];
 
-        //$langIsoIds = Language::getIsoIds();
         $langEntities = $this->langRepository->findBy(['active' => 1]);
         foreach ($langEntities as $langEntity) {
             $default_name[$langEntity->getId()] = $langEntity->getIsoCode();

--- a/src/Form/ProductCommentCriterionFormDataProvider.php
+++ b/src/Form/ProductCommentCriterionFormDataProvider.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\ProductComment\Form;
+
+use PrestaShop\Module\ProductComment\Repository\ProductCommentCriterionRepository;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\FormDataProviderInterface;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+
+class ProductCommentCriterionFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var ProductCommentCriterionRepository
+     */
+    private $pccriterionRepository;
+
+    /**
+     * @var LangRepository
+     */
+    private $langRepository;
+
+    /**
+     * @param ProductCommentCriterionRepository $pccriterionRepository
+     * @param LangRepository $langRepository
+     */
+    public function __construct(
+        ProductCommentCriterionRepository $pccriterionRepository,
+        LangRepository $langRepository
+    ) {
+        $this->pccriterionRepository = $pccriterionRepository;
+        $this->langRepository = $langRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($criterionId)
+    {
+        $criterion = $this->pccriterionRepository->find($criterionId);
+
+        $criterionData = [
+            'type' => $criterion->getType(),
+            'active' => $criterion->isActive(),
+        ];
+        foreach ($criterion->getCriterionLangs() as $criterionLang) {
+            $criterionData['name'][$criterionLang->getLang()->getId()] = $criterionLang->getName();
+        }
+
+        return $criterionData;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultData()
+    {
+        $default_name = [];
+
+        //$langIsoIds = Language::getIsoIds();
+        $langEntities = $this->langRepository->findBy(['active' => 1]);
+        foreach ($langEntities as $langEntity) {
+            $default_name[$langEntity->getId()] = $langEntity->getIsoCode();
+        }
+
+        return [
+            'type' => '',
+            'active' => false,
+            'name' => $default_name,
+        ];
+    }
+}

--- a/src/Form/index.php
+++ b/src/Form/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Repository/ProductCommentCriterionRepository.php
+++ b/src/Repository/ProductCommentCriterionRepository.php
@@ -88,6 +88,9 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
         }
     }
 
+    /**
+     * @deprecated 6.0.3 - cascade remove by Entity setting instead
+     */
     private function deleteLangs($criterion): int
     {
         return $this->connection->executeUpdate('
@@ -112,33 +115,34 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     private function deleteGrades($criterion): int
     {
         return $this->connection->executeUpdate('
-            DELETE FROM `' . _DB_PREFIX_ . 'product_comment_criterion_grade`
+            DELETE FROM `' . _DB_PREFIX_ . 'product_comment_grade`
             WHERE `id_product_comment_criterion` = ' . $criterion->getId());
     }
 
-    /* Remove a criterion and Delete its manual relation _lang, _category, _product, _grade */
+    /* Remove a criterion and Delete its manual relation _category, _product, _grade */
     public function delete(ProductCommentCriterion $criterion): int
     {
         $res = 0;
 
         $criterionType = $criterion->getType();
 
-        $this->remove($criterion, true);
-
-        $res += $this->deleteLangs($criterion);
-
         if ($criterionType == ProductCommentCriterion::CATEGORIES_TYPE) {
             $res += $this->deleteCategories($criterion);
         } elseif ($criterionType == ProductCommentCriterion::PRODUCTS_TYPE) {
             $res += $this->deleteProducts($criterion);
+        } else {
+            $res = 1;
         }
 
         $res += $this->deleteGrades($criterion);
 
+        $this->remove($criterion, true);
+
+        // todo: return void, and use try catch Exception instead
         return $res;
     }
 
-    /* Update a criterion and Update its manual relation _lang, _category, _product, _grade */
+    /* Update a criterion and Update its manual relation _category, _product */
     public function update(ProductCommentCriterion $criterion): int
     {
         $res = 0;
@@ -148,20 +152,23 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
         $this->getEntityManager()->persist($criterion);
         $this->getEntityManager()->flush();
 
-        $res += $this->deleteLangs($criterion);
-        $res += $this->updateLangs($criterion);
-
         if ($criterionType == ProductCommentCriterion::CATEGORIES_TYPE) {
             $res += $this->deleteCategories($criterion);
             $res += $this->updateCategories($criterion);
         } elseif ($criterionType == ProductCommentCriterion::PRODUCTS_TYPE) {
             $res += $this->deleteProducts($criterion);
             $res += $this->updateProducts($criterion);
+        } else {
+            $res = 1;
         }
 
+        // todo: return void, and use try catch Exception instead
         return $res;
     }
 
+    /**
+     * @deprecated 6.0.3 - migrated to Form\ProductCommentCriterionFormDataHandler
+     */
     private function updateLangs($criterion): int
     {
         $res = 0;
@@ -217,15 +224,18 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
         return $res;
     }
 
+    public function updateGeneral(ProductCommentCriterion $criterion): void
+    {
+        $this->getEntityManager()->persist($criterion);
+        $this->getEntityManager()->flush();
+    }
+
     /**
-     * @param int $idProduct
-     * @param int $idLang
-     *
      * @return array
      *
      * @throws \PrestaShopException
      */
-    public function getByProduct($idProduct, $idLang)
+    public function getByProduct(int $idProduct, int $idLang)
     {
         /** @var QueryBuilder $qb */
         $qb = $this->connection->createQueryBuilder();
@@ -255,11 +265,9 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     }
 
     /**
-     * Get Criterions
-     *
      * @return array Criterions
      */
-    public function getCriterions($id_lang, $type = false, $active = false)
+    public function getCriterions(int $id_lang, $type = false, $active = false)
     {
         $sql = '
             SELECT pcc.`id_product_comment_criterion`, pcc.id_product_comment_criterion_type, pccl.`name`, pcc.active
@@ -278,8 +286,6 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param int $id_criterion
-     *
      * @return array
      */
     public function getProducts(int $id_criterion)
@@ -302,8 +308,6 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param int $id_criterion
-     *
      * @return array
      */
     public function getCategories(int $id_criterion)
@@ -340,25 +344,14 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     }
 
     /**
-     * Get Criterion with names in active languages
-     *
      * @return ProductCommentCriterion
+     *
+     * @deprecated 6.0.3 - use standard find() instead
      */
     public function findRelation($id_criterion)
     {
         if ($id_criterion > 0) {
             $criterion = $this->find($id_criterion);
-            $sql = '
-            SELECT `id_lang`, `name`
-            FROM `' . _DB_PREFIX_ . 'product_comment_criterion_lang` pccl			
-            WHERE pccl.id_product_comment_criterion = ' . $id_criterion . '
-            ORDER BY pccl.`id_lang` ASC';
-            $langNames = $this->connection->executeQuery($sql)->fetchAll();
-            $langArray = [];
-            foreach ($langNames as $langName) {
-                $langArray[$langName['id_lang']] = $langName['name'];
-            }
-            $criterion->setNames($langArray);
         } else {
             $criterion = new ProductCommentCriterion();
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Replace manual lang field process for Criterion by standard Doctrine relation. <br />Migrate some legacy functions to standard Symfony FormData Provider and Handler.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | PrestaShop/PrestaShop/discussions/34472
| How to test?  | 1. Apply this PR changes. <br> 2. In FO: clear browser cache & In BO: Performance > clear cache (required as there are 2 new-added services). <br> 3. Check all module features in both FO and BO to make sure they work as usual, especially multilingual feature for criterion name.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
