### PR TITLE
disable Write your view in QuickView refresh

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -1072,9 +1072,16 @@ class ProductComments extends Module implements WidgetInterface
             $idProduct = $this->context->controller->getProduct()->id;
             $variables = $this->getWidgetVariables($hookName, ['id_product' => $idProduct]);
 
-            $filePath = 'quickview' === Tools::getValue('action')
-                ? $tplHookPath . 'product-additional-info-quickview.tpl'
-                : $tplHookPath . 'product-additional-info.tpl';
+            switch (Tools::getValue('action')) {
+                case 'quickview':
+                    $filePath = $tplHookPath . 'product-additional-info-quickview.tpl';
+                    break;
+                case '':
+                    $filePath = $tplHookPath . 'product-additional-info.tpl';
+                    break;
+                default:    // 'refresh' and other unpredicted cases
+                    $filePath = '';
+            }
         }
 
         if (empty($variables) || empty($filePath)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The button `Write your review` should not be displayed in the quick view.  More details in the related issue.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#29863
| How to test?  | Apply this PR, then check to make sure `Write your review` button does not appear in QuickView modal at **both** First load and Combination change. `Write your review` must be visible and workable in Product page as usual too ;)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
