### PR TITLE
Set 5 stars default

### DIFF
--- a/views/templates/hook/post-comment-modal.tpl
+++ b/views/templates/hook/post-comment-modal.tpl
@@ -75,7 +75,7 @@
                         <label>{$criterion.name|escape:'html':'UTF-8'}:</label>
                         <div
                           class="grade-stars"
-                          data-grade="3"
+                          data-grade="5"
                           data-input="criterion[{$criterion.id_product_comment_criterion}]">
                         </div>
                       </div>


### PR DESCRIPTION
Customers do not usually modify the stars since they go unnoticed. I have a store with reviews from very happy customers and they all leave 3 stars because they don't see what comes predefined

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         |  improvement 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
