### PR TITLE
Fix compatibility with Hummingbird theme

### DIFF
--- a/views/js/productListingComments.js
+++ b/views/js/productListingComments.js
@@ -43,7 +43,7 @@ var productListingComments = (function () {
         productListReviewsContainer: '.product-list-reviews',
         productListReviewsNumberOfComments: '.comments-nb',
         productListReviewsStarsContainer: '.grade-stars',
-        productContainer: '.thumbnail-container'
+        productContainer: '.js-product-miniature'
     };
 
     var DOMClasses =  {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Hummingbird theme loads product rating outside `thumbnail-container`. Selector must consider whole product miniature, not just the product cover where rating is loaded in Classic theme.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | See https://github.com/PrestaShop/hummingbird/pull/584
| How to test?  | Check visibility in Classic and Hummingbird. https://github.com/PrestaShop/hummingbird/pull/584 needs to be merged first for Hummingbird.

### Classic
![obraz](https://github.com/PrestaShop/productcomments/assets/5007456/4621f6b3-85a0-458c-833d-1ec7964d712c)

### Hummingbird
![obraz](https://github.com/PrestaShop/productcomments/assets/5007456/afdf3b35-ae58-46a0-b79e-52ad29ada0d1)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
