### PR TITLE
Use on delete cascade on foreign keys

### DIFF
--- a/src/Entity/ProductCommentGrade.php
+++ b/src/Entity/ProductCommentGrade.php
@@ -37,7 +37,7 @@ class ProductCommentGrade
     /**
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="ProductComment")
-     * @ORM\JoinColumn(name="id_product_comment", referencedColumnName="id_product_comment")
+     * @ORM\JoinColumn(name="id_product_comment", referencedColumnName="id_product_comment", onDelete="CASCADE")
      */
     private $comment;
 

--- a/src/Entity/ProductCommentReport.php
+++ b/src/Entity/ProductCommentReport.php
@@ -37,7 +37,7 @@ class ProductCommentReport
     /**
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="ProductComment")
-     * @ORM\JoinColumn(name="id_product_comment", referencedColumnName="id_product_comment")
+     * @ORM\JoinColumn(name="id_product_comment", referencedColumnName="id_product_comment", onDelete="CASCADE")
      *
      * @var ProductComment
      */

--- a/src/Entity/ProductCommentUsefulness.php
+++ b/src/Entity/ProductCommentUsefulness.php
@@ -37,7 +37,7 @@ class ProductCommentUsefulness
     /**
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="ProductComment")
-     * @ORM\JoinColumn(name="id_product_comment", referencedColumnName="id_product_comment")
+     * @ORM\JoinColumn(name="id_product_comment", referencedColumnName="id_product_comment", onDelete="CASCADE")
      */
     private $comment;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The foreign keys need `on delete cascade` in order to allow deletion of a product comment.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#35523.
| How to test?  | Run `php bin/console doctrine:schema:update --dump-sql` and compare the output. Apply both versions of the SQL script to the DB and test for each the deletion of a product comment in the BO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
