### PR TITLE
Change min compatibility & module version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.7', '1.7.8', '8.0', 'latest']
+        presta-versions: ['1.7.8', '8.0', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Allow users to post reviews on your products and/or rate them based on specific 
 
 ## Compatibility
 
-PrestaShop: `1.7.7` or newer
+PrestaShop: `1.7.8` or newer
 
 ## Multistore compatibility
 

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>productcomments</name>
     <displayName><![CDATA[Product Comments]]></displayName>
-    <version><![CDATA[6.0.3]]></version>
+    <version><![CDATA[7.0.0]]></version>
     <description><![CDATA[Allows users to post reviews and rate products on specific criteria.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/productcomments.php
+++ b/productcomments.php
@@ -60,7 +60,7 @@ class ProductComments extends Module implements WidgetInterface
         $this->langId = $this->context->language->id;
         $this->shopId = $this->context->shop->id ? $this->context->shop->id : Configuration::get('PS_SHOP_DEFAULT');
 
-        $this->ps_versions_compliancy = ['min' => '1.7.7', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.8', 'max' => _PS_VERSION_];
     }
 
     public function install($keep = true)

--- a/productcomments.php
+++ b/productcomments.php
@@ -47,7 +47,7 @@ class ProductComments extends Module implements WidgetInterface
     {
         $this->name = 'productcomments';
         $this->tab = 'front_office_features';
-        $this->version = '6.0.3';
+        $this->version = '7.0.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;

--- a/src/Entity/ProductCommentCriterion.php
+++ b/src/Entity/ProductCommentCriterion.php
@@ -67,7 +67,7 @@ class ProductCommentCriterion
     /**
      * @var array
      *
-     * @deprecated 6.0.3 - use criterionLangs instead
+     * @deprecated 7.0.0 - use criterionLangs instead
      */
     private $names;
 
@@ -139,7 +139,7 @@ class ProductCommentCriterion
     /**
      * @return array
      *
-     * @deprecated 6.0.3 - migrated to Form\ProductCommentCriterionFormDataProvider
+     * @deprecated 7.0.0 - migrated to Form\ProductCommentCriterionFormDataProvider
      */
     public function getNames()
     {
@@ -151,7 +151,7 @@ class ProductCommentCriterion
      *
      * @return ProductCommentCriterion
      *
-     * @deprecated 6.0.3
+     * @deprecated 7.0.0
      */
     public function setNames($langNames)
     {

--- a/src/Repository/ProductCommentCriterionRepository.php
+++ b/src/Repository/ProductCommentCriterionRepository.php
@@ -89,7 +89,7 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     }
 
     /**
-     * @deprecated 6.0.3 - cascade remove by Entity setting instead
+     * @deprecated 7.0.0 - cascade remove by Entity setting instead
      */
     private function deleteLangs($criterion): int
     {
@@ -167,7 +167,7 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     }
 
     /**
-     * @deprecated 6.0.3 - migrated to Form\ProductCommentCriterionFormDataHandler
+     * @deprecated 7.0.0 - migrated to Form\ProductCommentCriterionFormDataHandler
      */
     private function updateLangs($criterion): int
     {
@@ -346,7 +346,7 @@ class ProductCommentCriterionRepository extends ServiceEntityRepository
     /**
      * @return ProductCommentCriterion
      *
-     * @deprecated 6.0.3 - use standard find() instead
+     * @deprecated 7.0.0 - use standard find() instead
      */
     public function findRelation($id_criterion)
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since 6.0.3 introduced a big change regarding some symfony services, we decided to up the min version and release a 7.0.0 to avoid problems with the 1.7.7.x compatibility.
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? | yes
| Issue | #35886
| How to test?  | upgrade the module on 1.7.8.x and upward is ok.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
