### PR TITLE
Prevent MakeRatingMandatory feature breaks review in 3rd party theme

### DIFF
--- a/views/js/post-comment.js
+++ b/views/js/post-comment.js
@@ -40,6 +40,8 @@ jQuery(document).ready(function () {
   const commentPostErrorModal = $('#product-comment-post-error');
 
   const criterionsList = $('#criterions_list');
+  if (typeof productCommentMandatoryMessage === 'undefined')
+    productCommentMandatoryMessage = 'Please choose a rating for your review.';
   criterionsList.append('<div id="ratingNotChosen">* ' + productCommentMandatoryMessage + '</div>');
   const criterionsInfo = $('#ratingNotChosen');  
 
@@ -128,7 +130,7 @@ jQuery(document).ready(function () {
         $(fieldSelector).removeClass('error');
         $(fieldSelector).addClass('valid');
       }
-           
+      
       if (!ratingChosen) {
         criterionsInfo.show();
         isValid = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Third party themes with override template for productcomments 7.0.0 will face bug when submitting review if the translation string for MakeRatingMandatory is not added in themes yet. <br/> The issue was locally solved in hummingbird beta but still happens in hummingbird 0.2.0.<br/> This PR solve the issue globally for all themes. If the shop owner want to use their own translation string then they must take care escape characters themselves ;)
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#36093
| How to test?  | Test with productcomments 7.0.0 and hummingbird 0.2.0 on PS 1.7.8+. <br/> Before PR you will see the issue as described in the above ticket, after PR the issue won't happen.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
