### PR TITLE
Fixed issues with updating the note in quickview and hook display on product update

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -1076,11 +1076,19 @@ class ProductComments extends Module implements WidgetInterface
                 case 'quickview':
                     $filePath = $tplHookPath . 'product-additional-info-quickview.tpl';
                     break;
+                case 'refresh':
+                    if (Tools::getValue('quickview') == true) {
+                        $filePath = '';
+                    } else {
+                        $filePath = $tplHookPath . 'product-additional-info.tpl';
+                    }
+                    break;
                 case '':
                     $filePath = $tplHookPath . 'product-additional-info.tpl';
                     break;
-                default:    // 'refresh' and other unpredicted cases
+                default:
                     $filePath = '';
+                    break;
             }
         }
 

--- a/views/templates/hook/product-additional-info-quickview.tpl
+++ b/views/templates/hook/product-additional-info-quickview.tpl
@@ -24,15 +24,22 @@
  *}
 
 {if $nb_comments != 0}
-  <script type="text/javascript">    
-    $('#product-quickview-{$product.id}').insertAfter($('.quickview #product-description-short'));
-    $('#product-quickview-{$product.id} .grade-stars').rating({ grade: {$average_grade} });
-    $('#product-quickview-{$product.id} .comments-nb').html('({$nb_comments})');
+  <script type="text/javascript">
+    function renderQuickViewNote() {
+      $('#product-quickview-{$product.id}').insertAfter($('.quickview #product-description-short'));
+      $('#product-quickview-{$product.id} .grade-stars').rating({ grade: {$average_grade} });
+      $('#product-quickview-{$product.id} .comments-nb').html('({$nb_comments})');
+    }
+
+    renderQuickViewNote();
+
+    prestashop.on('updatedProduct', function(){
+      renderQuickViewNote();
+    });
   </script>
 
   <div id="product-quickview-{$product.id}" class="product-quickview-review">
     <div class="grade-stars"></div>
     <div class="comments-nb"></div>
   </div>
-</div>
 {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR fix grade update on quickview when product is updated and also fix a render issue 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/36335
| How to test?  | ⬇️

- The following issue is fixed and describe here : https://github.com/PrestaShop/PrestaShop/issues/36335
- Quickview update :
**Before:**

https://github.com/PrestaShop/productcomments/assets/110676325/02c0bda1-5cc5-4740-82a0-c103ddfdcd26

**After:**

https://github.com/PrestaShop/productcomments/assets/110676325/6f98a42d-ecad-4312-b39c-ba27f27057da


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
