### PR TITLE
Fix productcomments when not logged

### DIFF
--- a/controllers/front/PostComment.php
+++ b/controllers/front/PostComment.php
@@ -34,7 +34,7 @@ class ProductCommentsPostCommentModuleFrontController extends ModuleFrontControl
     public function display()
     {
         header('Content-Type: application/json');
-        if (!(int) $this->context->cookie->id_customer && !Configuration::get('PRODUCT_COMMENTS_ALLOW_GUESTS')) {
+        if (!$this->context->customer->isLogged() && !Configuration::get('PRODUCT_COMMENTS_ALLOW_GUESTS')) {
             $this->ajaxRender(
                 json_encode(
                     [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When a customer is not logged, it is possible to publish a review if the customer informations are in the cookie. We should check if the customer is logged or not with $this->context->customer->isLogged() instead of checking the cookie.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Go to Back Office, configure module productcomments and disallow guest to post reviews. Go to Front Office and post a review in a product : if you are not logged a error message should display, if you are logged then the review is posted.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
