### PR TITLE
Provide absolute URL to fix routing issues

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -455,11 +455,7 @@ class ProductComments extends Module implements WidgetInterface
             $helper->table = $this->name;
             $helper->table_id = 'waiting-approval-productcomments-list';
             $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
-			    'configure'   => $this->name,
-			    'tab_module'  => $this->tab,
-			    'module_name' => $this->name,
-			]);
+            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
             $helper->no_link = true;
 
             $return .= $helper->generateList($comments, $fields_list);
@@ -484,11 +480,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'reported-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
-		    'configure'   => $this->name,
-		    'tab_module'  => $this->tab,
-		    'module_name' => $this->name,
-		]);
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
         $helper->no_link = true;
 
         $return .= $helper->generateList($comments, $fields_list);
@@ -572,11 +564,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->title = $this->trans('Review Criteria', [], 'Modules.Productcomments.Admin');
         $helper->table = $this->name . 'criterion';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
-		    'configure'   => $this->name,
-		    'tab_module'  => $this->tab,
-		    'module_name' => $this->name,
-		]);
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
 
         return $helper->generateList($criterions, $fields_list);
     }
@@ -597,11 +585,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'approved-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
-		    'configure'   => $this->name,
-		    'tab_module'  => $this->tab,
-		    'module_name' => $this->name,
-		]);
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
         $helper->no_link = true;
 
         $page = ($page = Tools::getValue('submitFilter' . $helper->list_id)) ? (int) $page : 1;

--- a/productcomments.php
+++ b/productcomments.php
@@ -455,7 +455,7 @@ class ProductComments extends Module implements WidgetInterface
             $helper->table = $this->name;
             $helper->table_id = 'waiting-approval-productcomments-list';
             $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
+            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure' => $this->name, 'tab_module' => $this->tab, 'module_name' => $this->name]);
             $helper->no_link = true;
 
             $return .= $helper->generateList($comments, $fields_list);
@@ -480,7 +480,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'reported-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure' => $this->name, 'tab_module' => $this->tab, 'module_name' => $this->name]);
         $helper->no_link = true;
 
         $return .= $helper->generateList($comments, $fields_list);
@@ -564,7 +564,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->title = $this->trans('Review Criteria', [], 'Modules.Productcomments.Admin');
         $helper->table = $this->name . 'criterion';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure' => $this->name, 'tab_module' => $this->tab, 'module_name' => $this->name]);
 
         return $helper->generateList($criterions, $fields_list);
     }
@@ -585,7 +585,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'approved-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure'   => $this->name, 'tab_module'  => $this->tab, 'module_name' => $this->name]);
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], ['configure' => $this->name, 'tab_module' => $this->tab, 'module_name' => $this->name]);
         $helper->no_link = true;
 
         $page = ($page = Tools::getValue('submitFilter' . $helper->list_id)) ? (int) $page : 1;

--- a/productcomments.php
+++ b/productcomments.php
@@ -455,7 +455,11 @@ class ProductComments extends Module implements WidgetInterface
             $helper->table = $this->name;
             $helper->table_id = 'waiting-approval-productcomments-list';
             $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
+			    'configure'   => $this->name,
+			    'tab_module'  => $this->tab,
+			    'module_name' => $this->name,
+			]);
             $helper->no_link = true;
 
             $return .= $helper->generateList($comments, $fields_list);
@@ -480,7 +484,11 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'reported-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
+		    'configure'   => $this->name,
+		    'tab_module'  => $this->tab,
+		    'module_name' => $this->name,
+		]);
         $helper->no_link = true;
 
         $return .= $helper->generateList($comments, $fields_list);
@@ -564,7 +572,11 @@ class ProductComments extends Module implements WidgetInterface
         $helper->title = $this->trans('Review Criteria', [], 'Modules.Productcomments.Admin');
         $helper->table = $this->name . 'criterion';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
+		    'configure'   => $this->name,
+		    'tab_module'  => $this->tab,
+		    'module_name' => $this->name,
+		]);
 
         return $helper->generateList($criterions, $fields_list);
     }
@@ -585,7 +597,11 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'approved-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false, [], [
+		    'configure'   => $this->name,
+		    'tab_module'  => $this->tab,
+		    'module_name' => $this->name,
+		]);
         $helper->no_link = true;
 
         $page = ($page = Tools::getValue('submitFilter' . $helper->list_id)) ? (int) $page : 1;

--- a/productcomments.php
+++ b/productcomments.php
@@ -455,7 +455,7 @@ class ProductComments extends Module implements WidgetInterface
             $helper->table = $this->name;
             $helper->table_id = 'waiting-approval-productcomments-list';
             $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+            $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
             $helper->no_link = true;
 
             $return .= $helper->generateList($comments, $fields_list);
@@ -480,7 +480,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'reported-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->no_link = true;
 
         $return .= $helper->generateList($comments, $fields_list);
@@ -564,7 +564,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->title = $this->trans('Review Criteria', [], 'Modules.Productcomments.Admin');
         $helper->table = $this->name . 'criterion';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
 
         return $helper->generateList($criterions, $fields_list);
     }
@@ -585,7 +585,7 @@ class ProductComments extends Module implements WidgetInterface
         $helper->table = $this->name;
         $helper->table_id = 'approved-productcomments-list';
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->no_link = true;
 
         $page = ($page = Tools::getValue('submitFilter' . $helper->list_id)) ? (int) $page : 1;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Provide absolute URL to fix routing issues. Fixes potential issues coming from relative URLs not being reliable after symfony migration. See https://github.com/PrestaShop/PrestaShop/issues/39185. cc @Touxten 
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39185
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Just test the module can be configured correctly and loads in the backoffice, so we didn't break anything or have some typo. (On nginx server, this could be problematic.)
