### PR TITLE
Fix grade stars init in comment list header

### DIFF
--- a/views/js/list-comments.js
+++ b/views/js/list-comments.js
@@ -39,6 +39,7 @@ jQuery(document).ready(function () {
   const nextCount = totalPages + 1;
   const gapText = '&hellip;';
 
+  $('#product-comments-list-header .grade-stars').rating();
   $('#product-comments-list .grade-stars').rating();
   $('.product-comments-additional-info .grade-stars').rating();
 
@@ -47,6 +48,7 @@ jQuery(document).ready(function () {
   })
 
   document.addEventListener('updateRating', function() {
+    $('#product-comments-list-header .grade-stars').rating();
     $('#product-comments-list .grade-stars').rating();
     $('.product-comments-additional-info .grade-stars').rating();
   });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | In module version 8, the stars at the bottom of the product page are no longer initialized.
| Type?             | bug fix
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes PrestaShop/Prestashop#40598
| How to test?      | Clear assets cache and refresh page
| Sponsor company   | 

