### PR TITLE
Fix cache issue when product list is being shown

### DIFF
--- a/productcomments.php
+++ b/productcomments.php
@@ -1098,7 +1098,7 @@ class ProductComments extends Module implements WidgetInterface
 
         $this->smarty->assign($variables);
 
-        return $this->fetch($filePath);
+        return $this->fetch($filePath, $this->getCacheId($idProduct));
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | When calling the `product.tpl` template from a custom hook, the `displayProductListReviews` is executed successively for different products. I can see (XDebug) the `fetch` being called with different parameters each time. However, for internal reasons, the returned string always corresponds to the first call to `fetch` (from the first product) resulting in the same review being displayed for all products. When passing a appropriate $cache_id, the issue is resolved.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Test the display of the widget with multiple products (product list as in categories)
| Sponsor company   | Shato

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
