### PR TITLE
Update ProductCommentRepository.php

### DIFF
--- a/src/Repository/ProductCommentRepository.php
+++ b/src/Repository/ProductCommentRepository.php
@@ -307,6 +307,7 @@ class ProductCommentRepository extends ServiceEntityRepository
         $sql = 'SELECT';
 
         $count = count($productIds);
+		$productIds = array_values($productIds);
 
         foreach ($productIds as $index => $id) {
             $esqID = (int) $id;
@@ -372,6 +373,7 @@ class ProductCommentRepository extends ServiceEntityRepository
         $sql = 'SELECT';
 
         $count = count($productIds);
+		$productIds = array_values($productIds);
 
         foreach ($productIds as $index => $id) {
             $esqID = (int) $id;


### PR DESCRIPTION
Fixes #226 issue
$productIds parameter array causes an error because it is not sorted.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | $productIds parameter array causes an error because it is not sorted.
| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/productcomments#226.
| How to test?      | Once add a comment to a product and approve from backoffice, after turn to front office a product listing page, inspect on chrome, show network tab, filter Fetch/XHR, find /prestashop/module/productcomments/CommentGrade request and see error.
| Sponsor company   | Metin EREN.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
